### PR TITLE
#17 공용 버튼

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -3,7 +3,15 @@ import type { ComponentProps, ReactNode } from "react";
 
 interface ButtonProps extends ComponentProps<"button"> {
   variant?: "default" | "outline";
-  color?: "primary" | "secondary" | "error" | "neutral";
+  color?:
+    | "primary"
+    | "primary-thick"
+    | "primary-soft"
+    | "secondary"
+    | "secondary-thick"
+    | "secondary-soft"
+    | "error"
+    | "neutral";
   children: ReactNode;
 }
 
@@ -11,7 +19,11 @@ const getVariantClasses = (variant: ButtonProps["variant"], color: ButtonProps["
   if (variant === "outline") {
     return clsx("border border-1 bg-bg-primary", {
       "border-primary": color === "primary",
+      "border-primary-thick": color === "primary-thick",
+      "border-primary-soft": color === "primary-soft",
       "border-secondary": color === "secondary",
+      "border-secondary-thick": color === "secondary-thick",
+      "border-secondary-soft": color === "secondary-soft",
       "border-error": color === "error",
       "border-neutral-600": color === "neutral",
     });
@@ -19,11 +31,16 @@ const getVariantClasses = (variant: ButtonProps["variant"], color: ButtonProps["
 
   return clsx({
     "bg-primary": color === "primary",
+    "bg-primary-thick": color === "primary-thick",
+    "bg-primary-soft": color === "primary-soft",
     "bg-secondary": color === "secondary",
+    "bg-secondary-thick": color === "secondary-thick",
+    "bg-secondary-soft": color === "secondary-soft",
     "bg-error": color === "error",
     "bg-neutral-600": color === "neutral",
   });
 };
+
 export default function Button({
   variant = "default",
   color = "primary",

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,46 @@
+import clsx from "clsx";
+import type { ComponentProps, ReactNode } from "react";
+
+interface ButtonProps extends ComponentProps<"button"> {
+  variant?: "default" | "outline";
+  color?: "primary" | "secondary" | "error" | "neutral";
+  children: ReactNode;
+}
+
+const getVariantClasses = (variant: ButtonProps["variant"], color: ButtonProps["color"]) => {
+  if (variant === "outline") {
+    return clsx("border border-1 bg-bg-primary", {
+      "border-primary": color === "primary",
+      "border-secondary": color === "secondary",
+      "border-error": color === "error",
+      "border-neutral-600": color === "neutral",
+    });
+  }
+
+  return clsx({
+    "bg-primary": color === "primary",
+    "bg-secondary": color === "secondary",
+    "bg-error": color === "error",
+    "bg-neutral-600": color === "neutral",
+  });
+};
+export default function Button({
+  variant = "default",
+  color = "primary",
+  className,
+  children,
+  ...rest
+}: ButtonProps) {
+  return (
+    <button
+      className={clsx(
+        "px-5 py-2 rounded-xl transition-all active:scale-95 hover:cursor-pointer hover:scale-105 focus:outline-none",
+        getVariantClasses(variant, color),
+        className
+      )}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+}


### PR DESCRIPTION
## 📌 개요

공용 버튼 컴포넌트

hover 및 클릭 시 각각 커지고 작아지는 애니메이션 있음

아래 variant와 색상조합으로 사용가능
variant: default, ouline
color: primary, secondary, error, neutral (primary와 second는 thick와 soft 까지)

## ✅ 작업 내용

- 공용 버튼 컴포넌트 생성

## 🔍 관련 이슈

Closes #17 

## 📸 스크린샷 (선택)
### 예시코드
```jsx
    <div className="text-text-primary flex flex-col items-center space-y-1 bg-bg-primary p-19 h-screen">
      <Button>
        <Text className="text-text-on-dark">버튼 1</Text>
      </Button>
      <Button variant="outline">
        <Text>버튼 1</Text>
      </Button>
      <Button color="secondary">
        <Text className="text-text-on-dark">버튼 2</Text>
      </Button>
      <Button color="secondary" variant="outline">
        <Text>버튼 2</Text>
      </Button>
      <Button color="neutral">
        <Text className="text-text-on-dark">버튼 3</Text>
      </Button>
      <Button color="neutral" variant="outline">
        <Text>버튼 3</Text>
      </Button>
      <Button color="error">
        <Text className="text-text-on-dark">에러 버튼</Text>
      </Button>
      <Button color="error" variant="outline">
        <Text>에러 버튼</Text>
      </Button>
    </div>
```
<img width="652" height="513" alt="Screenshot 2025-08-04 at 3 34 46 PM" src="https://github.com/user-attachments/assets/f8fdb3ac-b245-4840-a133-ea9b7e7f6db1" />

