### PR TITLE
#30 api response type(타입 실수 제거)

### DIFF
--- a/src/types/api-response.d.ts
+++ b/src/types/api-response.d.ts
@@ -37,23 +37,20 @@ interface UserProfileDetail {
   regions: Region[];
   positions: PositionAndLevel[];
   genres: Genre[];
-  recent_posts: RecentPost[];
-  recent_comments: RecentComment[];
+  recent_posts: Post[];
+  recent_comments: Comment[];
 }
 
-export interface RecentComment {
+export interface Comment {
   id: string;
   content: string;
-  post: Post;
+  post: Pick<Post, "id" | "title">;
   created_at: Date;
 }
 
 export interface Post {
   id: string;
   title: string;
-}
-
-export interface RecentPost extends Post {
   created_at: Date;
 }
 

--- a/src/types/api-response.d.ts
+++ b/src/types/api-response.d.ts
@@ -159,3 +159,9 @@ interface MasterData {
   recruiting_post_types: PostType[];
   recruitment_types: RecruitmentType[];
 }
+
+/* --------------- 파일업로드 --------------- */
+// POST /api/v1/uploads/images
+interface UploadedImage {
+  image_url: string;
+}

--- a/src/types/api-response.d.ts
+++ b/src/types/api-response.d.ts
@@ -3,10 +3,10 @@ interface MyUserInfo {
   id: string;
   email: string;
   nickname: string;
-  profile: Profile;
+  profile: MyProfile;
 }
 
-interface Profile {
+interface MyProfile {
   image_url: string;
   is_public: boolean;
   regions: Region[];

--- a/src/types/api-response.d.ts
+++ b/src/types/api-response.d.ts
@@ -82,12 +82,12 @@ interface ExperienceLevel {
 
 /* --------------- 구인/구직 --------------- */
 // GET /api/v1/recruiting-posts
-export interface PostList {
+interface PostList {
   next_cursor: string;
   posts: Post[];
 }
 
-export interface Post {
+interface Post {
   id: string;
   title: string;
   author: Author;
@@ -99,27 +99,26 @@ export interface Post {
   comments_count: number;
   is_closed: boolean;
 }
-
-export interface Author {
+interface Author {
   user_id: string;
   nickname: string;
   image_url?: string;
 }
-export interface Orientation {
+interface Orientation {
   id: string;
   name: string;
 }
 
-export interface RecruitmentType {
+interface RecruitmentType {
   id: string;
   name: string;
 }
-export interface PostType {
+interface PostType {
   name: string;
 }
 
 //GET /api/v1/recruiting-posts/{post_id}
-export interface PostDetail extends Post {
+interface PostDetail extends Post {
   content: string;
   band_name: string;
   band_composition: string;

--- a/src/types/api-response.d.ts
+++ b/src/types/api-response.d.ts
@@ -148,6 +148,13 @@ interface CommentList {
   })[];
 }
 
+/* --------------- 북마크 --------------- */
+// GET /api/v1/users/me/bookmarks/profiles
+interface BookmarkUserList {
+  next_cursor: string;
+  profiles: (Omit<UserProfile, "is_bookmarked"> & { bookmark_id: string })[];
+}
+
 /* --------------- 공통 --------------- */
 //GET /api/v1/common/master-data
 interface MasterData {

--- a/src/types/api-response.d.ts
+++ b/src/types/api-response.d.ts
@@ -55,7 +55,7 @@ interface PostDetail extends Post {
   comments: Comment[];
 }
 
-/* --------------- 구인/구직 --------------- */
+/* --------------- 댓글 --------------- */
 //GET /api/v1/comments
 interface CommentList {
   next_cursor: string;

--- a/src/types/api-response.d.ts
+++ b/src/types/api-response.d.ts
@@ -92,8 +92,8 @@ interface Post {
   title: string;
   author: Author;
   is_bookmarked: boolean;
-  post_type: Pick<PostType, "name">;
-  regions: Pick<Region, "name">[];
+  post_type: PostType;
+  regions: Region[];
   created_at: Date;
   views_count: number;
   comments_count: number;

--- a/src/types/api-response.d.ts
+++ b/src/types/api-response.d.ts
@@ -94,6 +94,13 @@ interface UploadedImage {
   image_url: string;
 }
 
+/* --------------- 에러 --------------- */
+//에러가 나타났을 때 오는 코드
+interface ErrorResponse {
+  code: string;
+  message: string;
+}
+
 /* ----- 리스폰스로 오는 타입을 아니지만 내부적으로 사용되는 타입 ----- */
 interface MyProfile {
   image_url: string;

--- a/src/types/api-response.d.ts
+++ b/src/types/api-response.d.ts
@@ -14,17 +14,26 @@ interface UserList {
 }
 
 // GET /api/v1/profiles/{user_id}
-interface UserProfileDetail {
+type UserProfileDetail = PublicUserProfileDetail | PrivateUserProfileDetail;
+interface BaseUserProfileDetail {
   nickname: string;
   image_url: string;
   is_bookmarked: true;
+  is_public: boolean;
   regions: Region[];
   positions: PositionAndLevel[];
   genres: Genre[];
+}
+interface PublicUserProfileDetail extends BaseUserProfileDetail {
+  is_public: true;
   recent_posts: Pick<Post, "id" | "title" | "created_at">[];
   recent_comments: (Pick<Comment, "id" | "content" | "created_at"> & {
     post: Pick<Post, "id" | "title">;
   })[];
+}
+interface PrivateUserProfileDetail extends BaseUserProfileDetail {
+  is_public: false;
+  // `recent_posts`와 `recent_comments` 없음
 }
 
 /* --------------- 구인/구직 --------------- */

--- a/src/types/api-response.d.ts
+++ b/src/types/api-response.d.ts
@@ -18,7 +18,7 @@ type UserProfileDetail = PublicUserProfileDetail | PrivateUserProfileDetail;
 interface BaseUserProfileDetail {
   nickname: string;
   image_url: string;
-  is_bookmarked: true;
+  is_bookmarked: false;
   is_public: boolean;
   regions: Region[];
   positions: PositionAndLevel[];
@@ -153,7 +153,7 @@ interface UserProfile {
   user_id: string;
   nickname: string;
   image_url: string;
-  is_bookmarked: true;
+  is_bookmarked: boolean;
   regions: Region[];
   positions: PositionAndLevel[];
 }

--- a/src/types/api-response.d.ts
+++ b/src/types/api-response.d.ts
@@ -81,7 +81,7 @@ interface BookmarkUserList {
 }
 // GET /api/v1/users/me/bookmarks/recruiting-posts
 interface BookmarkPostList {
-  next_cursor: "string";
+  next_cursor: string;
   posts: (Omit<Post, "is_bookmarked"> & { bookmark_id: string })[];
 }
 

--- a/src/types/api-response.d.ts
+++ b/src/types/api-response.d.ts
@@ -154,6 +154,11 @@ interface BookmarkUserList {
   next_cursor: string;
   profiles: (Omit<UserProfile, "is_bookmarked"> & { bookmark_id: string })[];
 }
+// GET /api/v1/users/me/bookmarks/recruiting-posts
+interface BookmarkPostList {
+  next_cursor: "string";
+  posts: (Omit<Post, "is_bookmarked"> & { bookmark_id: string })[];
+}
 
 /* --------------- 공통 --------------- */
 //GET /api/v1/common/master-data

--- a/src/types/api-response.d.ts
+++ b/src/types/api-response.d.ts
@@ -14,6 +14,21 @@ interface MyProfile {
   genres: Genre[];
 }
 
+// GET /api/v1/profiles
+interface UserList {
+  next_cursor: string;
+  profiles: UserProfile[];
+}
+
+interface UserProfile {
+  user_id: string;
+  nickname: string;
+  image_url: string;
+  is_bookmarked: true;
+  regions: Region[];
+  positions: PositionAndLevel[];
+}
+
 interface PositionAndLevel {
   position: Position;
   experience_level: ExperienceLevel;

--- a/src/types/api-response.d.ts
+++ b/src/types/api-response.d.ts
@@ -92,8 +92,8 @@ interface Post {
   title: string;
   author: Author;
   is_bookmarked: boolean;
-  post_type: PostType;
-  regions: PostType[];
+  post_type: Pick<PostType, "name">;
+  regions: Pick<Region, "name">[];
   created_at: Date;
   views_count: number;
   comments_count: number;
@@ -114,6 +114,7 @@ interface RecruitmentType {
   name: string;
 }
 interface PostType {
+  id: string;
   name: string;
 }
 
@@ -138,10 +139,23 @@ interface PostDetail extends Post {
   comments: Comment[];
 }
 
+/* --------------- 구인/구직 --------------- */
 //GET /api/v1/comments
 interface CommentList {
   next_cursor: string;
   comments: (Pick<Comment, "id" | "content" | "created_at"> & {
     post: Pick<Post, "id" | "title">;
   })[];
+}
+
+/* --------------- 공통 --------------- */
+//GET /api/v1/common/master-data
+interface MasterData {
+  regions: Region[];
+  positions: Position[];
+  genres: Genre[];
+  experience_levels: ExperienceLevel[];
+  orientations: Orientation[];
+  recruiting_post_types: PostType[];
+  recruitment_types: RecruitmentType[];
 }

--- a/src/types/api-response.d.ts
+++ b/src/types/api-response.d.ts
@@ -7,27 +7,10 @@ interface MyUserInfo {
   profile: MyProfile;
 }
 
-interface MyProfile {
-  image_url: string;
-  is_public: boolean;
-  regions: Region[];
-  positions: PositionAndLevel[];
-  genres: Genre[];
-}
-
 // GET /api/v1/profiles
 interface UserList {
   next_cursor: string;
   profiles: UserProfile[];
-}
-
-interface UserProfile {
-  user_id: string;
-  nickname: string;
-  image_url: string;
-  is_bookmarked: true;
-  regions: Region[];
-  positions: PositionAndLevel[];
 }
 
 // GET /api/v1/profiles/{user_id}
@@ -44,78 +27,11 @@ interface UserProfileDetail {
   })[];
 }
 
-export interface Comment {
-  id: string;
-  author: {
-    user_id: string;
-    nickname: string;
-  };
-  content: string;
-  is_owner: boolean;
-  children: Comment[];
-}
-
-interface PositionAndLevel {
-  position: Position;
-  experience_level: ExperienceLevel;
-}
-
-interface Position {
-  id: string;
-  name: string;
-}
-
-interface Region {
-  id: string;
-  name: string;
-}
-
-interface Genre {
-  id: string;
-  name: string;
-}
-
-interface ExperienceLevel {
-  id: string;
-  name: string;
-}
-
 /* --------------- 구인/구직 --------------- */
 // GET /api/v1/recruiting-posts
 interface PostList {
   next_cursor: string;
   posts: Post[];
-}
-
-interface Post {
-  id: string;
-  title: string;
-  author: Author;
-  is_bookmarked: boolean;
-  post_type: PostType;
-  regions: Region[];
-  created_at: Date;
-  views_count: number;
-  comments_count: number;
-  is_closed: boolean;
-}
-interface Author {
-  user_id: string;
-  nickname: string;
-  image_url?: string;
-}
-interface Orientation {
-  id: string;
-  name: string;
-}
-
-interface RecruitmentType {
-  id: string;
-  name: string;
-}
-interface PostType {
-  id: string;
-  name: string;
 }
 
 //GET /api/v1/recruiting-posts/{post_id}
@@ -176,4 +92,88 @@ interface MasterData {
 // POST /api/v1/uploads/images
 interface UploadedImage {
   image_url: string;
+}
+
+/* ----- 리스폰스로 오는 타입을 아니지만 내부적으로 사용되는 타입 ----- */
+interface MyProfile {
+  image_url: string;
+  is_public: boolean;
+  regions: Region[];
+  positions: PositionAndLevel[];
+  genres: Genre[];
+}
+interface Post {
+  id: string;
+  title: string;
+  author: Author;
+  is_bookmarked: boolean;
+  post_type: PostType;
+  regions: Region[];
+  created_at: Date;
+  views_count: number;
+  comments_count: number;
+  is_closed: boolean;
+}
+interface Author {
+  user_id: string;
+  nickname: string;
+  image_url?: string;
+}
+interface Orientation {
+  id: string;
+  name: string;
+}
+
+interface RecruitmentType {
+  id: string;
+  name: string;
+}
+interface PostType {
+  id: string;
+  name: string;
+}
+
+interface UserProfile {
+  user_id: string;
+  nickname: string;
+  image_url: string;
+  is_bookmarked: true;
+  regions: Region[];
+  positions: PositionAndLevel[];
+}
+
+export interface Comment {
+  id: string;
+  author: {
+    user_id: string;
+    nickname: string;
+  };
+  content: string;
+  is_owner: boolean;
+  children: Comment[];
+}
+
+interface PositionAndLevel {
+  position: Position;
+  experience_level: ExperienceLevel;
+}
+
+interface Position {
+  id: string;
+  name: string;
+}
+
+interface Region {
+  id: string;
+  name: string;
+}
+
+interface Genre {
+  id: string;
+  name: string;
+}
+
+interface ExperienceLevel {
+  id: string;
+  name: string;
 }

--- a/src/types/api-response.d.ts
+++ b/src/types/api-response.d.ts
@@ -1,3 +1,4 @@
+/* --------------- 프로필 --------------- */
 // GET /api/v1/users/me
 interface MyUserInfo {
   id: string;
@@ -37,7 +38,7 @@ interface UserProfileDetail {
   regions: Region[];
   positions: PositionAndLevel[];
   genres: Genre[];
-  recent_posts: Post[];
+  recent_posts: Pick<Post, "id" | "title" | "created_at">[];
   recent_comments: Comment[];
 }
 
@@ -45,12 +46,6 @@ export interface Comment {
   id: string;
   content: string;
   post: Pick<Post, "id" | "title">;
-  created_at: Date;
-}
-
-export interface Post {
-  id: string;
-  title: string;
   created_at: Date;
 }
 
@@ -76,5 +71,34 @@ interface Genre {
 
 interface ExperienceLevel {
   id: string;
+  name: string;
+}
+
+/* --------------- 구인/구직 --------------- */
+// GET /api/v1/recruiting-posts
+export interface PostList {
+  next_cursor: string;
+  posts: Post[];
+}
+
+export interface Post {
+  id: string;
+  title: string;
+  author: Author;
+  is_bookmarked: boolean;
+  post_type: PostType;
+  regions: PostType[];
+  created_at: Date;
+  views_count: number;
+  comments_count: number;
+  is_closed: boolean;
+}
+
+export interface Author {
+  user_id: string;
+  nickname: string;
+}
+
+export interface PostType {
   name: string;
 }

--- a/src/types/api-response.d.ts
+++ b/src/types/api-response.d.ts
@@ -39,14 +39,20 @@ interface UserProfileDetail {
   positions: PositionAndLevel[];
   genres: Genre[];
   recent_posts: Pick<Post, "id" | "title" | "created_at">[];
-  recent_comments: Comment[];
+  recent_comments: (Pick<Comment, "id" | "content" | "created_at"> & {
+    post: Pick<Post, "id" | "title">;
+  })[];
 }
 
 export interface Comment {
   id: string;
+  author: {
+    user_id: string;
+    nickname: string;
+  };
   content: string;
-  post: Pick<Post, "id" | "title">;
-  created_at: Date;
+  is_owner: boolean;
+  children: Comment[];
 }
 
 interface PositionAndLevel {
@@ -97,8 +103,38 @@ export interface Post {
 export interface Author {
   user_id: string;
   nickname: string;
+  image_url?: string;
+}
+export interface Orientation {
+  id: string;
+  name: string;
 }
 
+export interface RecruitmentType {
+  id: string;
+  name: string;
+}
 export interface PostType {
   name: string;
+}
+
+//GET /api/v1/recruiting-posts/{post_id}
+export interface PostDetail extends Post {
+  content: string;
+  band_name: string;
+  band_composition: string;
+  activity_time: string;
+  orientation: Orientation;
+  contact_info: string;
+  application_method: string;
+  practice_frequency_time: string;
+  recruitment_type: RecruitmentType;
+  other_conditions: string;
+  genres: Genre[];
+  positions: {
+    position: Position;
+    desired_experience_level: ExperienceLevel;
+  }[];
+  is_owner: boolean;
+  comments: Comment[];
 }

--- a/src/types/api-response.d.ts
+++ b/src/types/api-response.d.ts
@@ -29,6 +29,34 @@ interface UserProfile {
   positions: PositionAndLevel[];
 }
 
+// GET /api/v1/profiles/{user_id}
+interface UserProfileDetail {
+  nickname: string;
+  image_url: string;
+  is_bookmarked: true;
+  regions: Region[];
+  positions: PositionAndLevel[];
+  genres: Genre[];
+  recent_posts: RecentPost[];
+  recent_comments: RecentComment[];
+}
+
+export interface RecentComment {
+  id: string;
+  content: string;
+  post: Post;
+  created_at: Date;
+}
+
+export interface Post {
+  id: string;
+  title: string;
+}
+
+export interface RecentPost extends Post {
+  created_at: Date;
+}
+
 interface PositionAndLevel {
   position: Position;
   experience_level: ExperienceLevel;

--- a/src/types/api-response.d.ts
+++ b/src/types/api-response.d.ts
@@ -137,3 +137,11 @@ interface PostDetail extends Post {
   is_owner: boolean;
   comments: Comment[];
 }
+
+//GET /api/v1/comments
+interface CommentList {
+  next_cursor: string;
+  comments: (Pick<Comment, "id" | "content" | "created_at"> & {
+    post: Pick<Post, "id" | "title">;
+  })[];
+}

--- a/src/types/api-response.d.ts
+++ b/src/types/api-response.d.ts
@@ -1,0 +1,40 @@
+// GET /api/v1/users/me
+interface MyUserInfo {
+  id: string;
+  email: string;
+  nickname: string;
+  profile: Profile;
+}
+
+interface Profile {
+  image_url: string;
+  is_public: boolean;
+  regions: Region[];
+  positions: PositionAndLevel[];
+  genres: Genre[];
+}
+
+interface PositionAndLevel {
+  position: Position;
+  experience_level: ExperienceLevel;
+}
+
+interface Position {
+  id: string;
+  name: string;
+}
+
+interface Region {
+  id: string;
+  name: string;
+}
+
+interface Genre {
+  id: string;
+  name: string;
+}
+
+interface ExperienceLevel {
+  id: string;
+  name: string;
+}


### PR DESCRIPTION
## 📌 개요

api response type들을 정의했습니다.

## ✅ 작업 내용

- api response에 필요한 모든 타입
- api response가 snake_case로 와서 예외적으로 snake_case 사용
- 실 코드에서 사용할 때는 camelCase로 바꿔서 사용해야합니다.
- is_bookmarked boolean으로 변경
- "string" -> string으로 변경

## 🔍 관련 이슈

Closes #30 

## 사용예시
```typescript
  const { data } = useQuery<UserProfileDetail | ErrorResponse>({
    queryKey: ["teat"],
    queryFn: () => {
      // query code
      ...
    }, 
  });
```

## 📸 스크린샷 (선택)

