### PR TITLE
#40 이미지 인풋 컴포넌트

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "clsx": "^2.1.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-dropzone": "^14.3.8",
         "react-hook-form": "^7.62.0",
         "react-icons": "^5.5.0",
         "react-router": "^7.7.1",
@@ -2058,6 +2059,15 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
+    "node_modules/attr-accept": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
+      "integrity": "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/axios": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
@@ -2728,6 +2738,18 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-selector": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-2.1.2.tgz",
+      "integrity": "sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -3064,7 +3086,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -3391,6 +3412,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3544,6 +3577,15 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -3701,6 +3743,17 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -3758,6 +3811,23 @@
         "react": "^19.1.1"
       }
     },
+    "node_modules/react-dropzone": {
+      "version": "14.3.8",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.3.8.tgz",
+      "integrity": "sha512-sBgODnq+lcA4P296DY4wacOZz3JFpD99fp+hb//iBO2HHnyeZU3FwWyXJ6salNpqQdsZrgMrotuko/BdJMV8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "attr-accept": "^2.2.4",
+        "file-selector": "^2.1.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8 || 18.0.0"
+      }
+    },
     "node_modules/react-hook-form": {
       "version": "7.62.0",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.62.0.tgz",
@@ -3781,6 +3851,12 @@
       "peerDependencies": {
         "react": "*"
       }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -4054,6 +4130,12 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "clsx": "^2.1.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-dropzone": "^14.3.8",
     "react-hook-form": "^7.62.0",
     "react-icons": "^5.5.0",
     "react-router": "^7.7.1",

--- a/src/components/input/ImageInput.tsx
+++ b/src/components/input/ImageInput.tsx
@@ -33,7 +33,7 @@ export default function ImageInput({ className, onChange }: ImageInputProps) {
   };
 
   return (
-    <div className={clsx("w-96", className)}>
+    <div className={clsx("w-[90%] max-w-96", className)}>
       {previewUrl ? (
         <div className="flex flex-col items-center space-y-1">
           <img src={previewUrl} alt="preview" className="w-full object-contain rounded-xl" />
@@ -49,7 +49,7 @@ export default function ImageInput({ className, onChange }: ImageInputProps) {
           </Button>
         </div>
       ) : (
-        <label className="flex flex-col justify-center items-center cursor-pointer border-2 border-dotted size-96 border-gray-600 rounded-xl bg-bg-primary transition-colors hover:bg-bg-secondary">
+        <label className="flex flex-col justify-center items-center cursor-pointer border-2 border-dotted aspect-square border-gray-600 rounded-xl bg-bg-primary transition-colors hover:bg-bg-secondary">
           {error ? (
             <Text variant="subText" className="text-error">
               {error}

--- a/src/components/input/ImageInput.tsx
+++ b/src/components/input/ImageInput.tsx
@@ -1,0 +1,28 @@
+import { useRef } from "react";
+import Text from "@/components/text/Text";
+
+export default function ImageInput() {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleClick = () => {
+    inputRef.current?.click();
+  };
+
+  return (
+    <div
+      className="flex justify-center items-center border-2 border-dotted size-96 border-gray-600 rounded-xl bg-bg-primary transition-colors hover:bg-bg-secondary"
+      onClick={handleClick}
+    >
+      <div className="flex flex-col justify-center items-center">
+        <Text variant="subText" className="text-center">
+          대표사진을 업로드해주세요.
+        </Text>
+        <Text variant="tooltip" className="text-center">
+          사진은 한 장, 5mb 이하, jpg 혹은 png 파일만 가능합니다.
+        </Text>
+      </div>
+
+      <input type="file" accept="image/*" className="hidden" ref={inputRef} />
+    </div>
+  );
+}

--- a/src/components/input/ImageInput.tsx
+++ b/src/components/input/ImageInput.tsx
@@ -1,96 +1,77 @@
-import { useRef, useState, type ComponentPropsWithRef } from "react";
+import { useState } from "react";
 import Text from "@/components/text/Text";
 import Button from "@/components/Button";
 import clsx from "clsx";
 
-export default function ImageInput({ className, ...rest }: ComponentPropsWithRef<"input">) {
-  const inputRef = useRef<HTMLInputElement | null>(null);
-  const [preview, setPreview] = useState<string | null>(null);
+interface ImageInputProps {
+  className?: string;
+  onChange?: (file: File | null) => void;
+}
+
+export default function ImageInput({ className, onChange }: ImageInputProps) {
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [error, setError] = useState("");
 
-  const handleClick = () => {
-    setError("");
-    inputRef.current?.click();
-  };
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-
+  const handleFile = (file: File | null) => {
     if (!file) return;
 
-    // 파일 타입, 크기 제한 검사
     const isValidType = ["image/jpeg", "image/png"].includes(file.type);
     const isValidSize = file.size <= 5 * 1024 * 1024;
 
     if (!isValidType || !isValidSize) {
-      setError("유효하지 않은 파일입니다. JPG 또는 PNG 파일이며, 5MB 이하여야 합니다.");
+      setError("유효하지 않은 파일입니다. JPG 또는 PNG, 5MB 이하만 가능");
+      onChange?.(null);
       return;
     }
 
+    setError("");
     const reader = new FileReader();
-    reader.onloadend = () => {
-      setPreview(reader.result as string);
-    };
+    reader.onloadend = () => setPreviewUrl(reader.result as string);
     reader.readAsDataURL(file);
+
+    onChange?.(file);
   };
 
-  return preview ? (
-    <Preview preview={preview} setPreview={setPreview} />
-  ) : (
-    <div
-      className={clsx(
-        "flex flex-col justify-center items-center border-2 border-dotted size-96 border-gray-600 rounded-xl bg-bg-primary transition-colors hover:bg-bg-secondary",
-        className
-      )}
-      onClick={handleClick}
-    >
-      <div className="flex flex-col justify-center items-center">
-        {error ? (
-          <Text variant="subText" className="text-error">
-            {error}
-          </Text>
-        ) : (
-          <>
-            <Text variant="subText" className="text-center">
-              대표사진을 업로드해주세요.
-            </Text>
-            <Text variant="tooltip" className="text-center">
-              사진은 한 장, 5mb 이하, jpg 혹은 png 파일만 가능합니다.
-            </Text>
-          </>
-        )}
-      </div>
-
-      <input
-        type="file"
-        accept="image/*"
-        className="hidden"
-        ref={inputRef}
-        onChange={handleChange}
-        {...rest}
-      />
-    </div>
-  );
-}
-
-interface PreviewProps {
-  preview: string;
-  setPreview: React.Dispatch<React.SetStateAction<string | null>>;
-}
-
-function Preview({ preview, setPreview }: PreviewProps) {
   return (
-    <div className="flex flex-col justify-center items-center w-96 space-y-1">
-      <img src={preview} alt="preview-image" className="w-full object-contain rounded-xl" />
-      <Button
-        onClick={() => {
-          setPreview("");
-        }}
-      >
-        <Text variant="label" className="text-text-on-dark">
-          다른 사진 고르기
-        </Text>
-      </Button>
+    <div className={clsx("w-96", className)}>
+      {previewUrl ? (
+        <div className="flex flex-col items-center space-y-1">
+          <img src={previewUrl} alt="preview" className="w-full object-contain rounded-xl" />
+          <Button
+            onClick={() => {
+              setPreviewUrl(null);
+              onChange?.(null);
+            }}
+          >
+            <Text variant="label" className="text-text-on-dark">
+              다른 사진 고르기
+            </Text>
+          </Button>
+        </div>
+      ) : (
+        <label className="flex flex-col justify-center items-center cursor-pointer border-2 border-dotted size-96 border-gray-600 rounded-xl bg-bg-primary transition-colors hover:bg-bg-secondary">
+          {error ? (
+            <Text variant="subText" className="text-error">
+              {error}
+            </Text>
+          ) : (
+            <>
+              <Text variant="subText" className="text-center">
+                대표사진을 업로드해주세요.
+              </Text>
+              <Text variant="tooltip" className="text-center">
+                JPG, PNG / 5MB 이하
+              </Text>
+            </>
+          )}
+          <input
+            type="file"
+            accept="image/png, image/jpeg"
+            className="hidden"
+            onChange={(e) => handleFile(e.target.files?.[0] ?? null)}
+          />
+        </label>
+      )}
     </div>
   );
 }

--- a/src/components/input/ImageInput.tsx
+++ b/src/components/input/ImageInput.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import Text from "@/components/text/Text";
 import Button from "@/components/Button";
 import clsx from "clsx";
+import { useDropzone } from "react-dropzone";
 
 interface ImageInputProps {
   className?: string;
@@ -32,6 +33,17 @@ export default function ImageInput({ className, onChange }: ImageInputProps) {
     onChange?.(file);
   };
 
+  const { getRootProps, getInputProps } = useDropzone({
+    accept: {
+      "image/jpeg": [],
+      "image/png": [],
+    },
+    maxFiles: 1,
+    onDrop: (acceptedFiles) => {
+      handleFile(acceptedFiles[0] ?? null);
+    },
+  });
+
   return (
     <div className={clsx("w-[90%] max-w-96", className)}>
       {previewUrl ? (
@@ -49,7 +61,10 @@ export default function ImageInput({ className, onChange }: ImageInputProps) {
           </Button>
         </div>
       ) : (
-        <label className="flex flex-col justify-center items-center cursor-pointer border-2 border-dotted aspect-square border-gray-600 rounded-xl bg-bg-primary transition-colors hover:bg-bg-secondary">
+        <div
+          {...getRootProps()}
+          className="flex flex-col justify-center items-center cursor-pointer border-2 border-dotted aspect-square border-gray-600 rounded-xl bg-bg-primary transition-colors hover:bg-bg-secondary"
+        >
           {error ? (
             <Text variant="subText" className="text-error">
               {error}
@@ -64,13 +79,8 @@ export default function ImageInput({ className, onChange }: ImageInputProps) {
               </Text>
             </>
           )}
-          <input
-            type="file"
-            accept="image/png, image/jpeg"
-            className="hidden"
-            onChange={(e) => handleFile(e.target.files?.[0] ?? null)}
-          />
-        </label>
+          <input {...getInputProps()} className="hidden" />
+        </div>
       )}
     </div>
   );

--- a/src/components/input/ImageInput.tsx
+++ b/src/components/input/ImageInput.tsx
@@ -33,7 +33,7 @@ export default function ImageInput({ className, onChange }: ImageInputProps) {
     onChange?.(file);
   };
 
-  const { getRootProps, getInputProps } = useDropzone({
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
     accept: {
       "image/jpeg": [],
       "image/png": [],
@@ -63,7 +63,10 @@ export default function ImageInput({ className, onChange }: ImageInputProps) {
       ) : (
         <div
           {...getRootProps()}
-          className="flex flex-col justify-center items-center cursor-pointer border-2 border-dotted aspect-square border-gray-600 rounded-xl bg-bg-primary transition-colors hover:bg-bg-secondary"
+          className={clsx(
+            "flex flex-col justify-center items-center cursor-pointer border-2 border-dotted aspect-square border-neutral-600 rounded-xl bg-bg-primary transition-colors hover:bg-primary-soft",
+            isDragActive ? "bg-primary-soft" : ""
+          )}
         >
           {error ? (
             <Text variant="subText" className="text-error">

--- a/src/components/input/ImageInput.tsx
+++ b/src/components/input/ImageInput.tsx
@@ -1,28 +1,91 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import Text from "@/components/text/Text";
+import Button from "@/components/Button";
 
 export default function ImageInput() {
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const [preview, setPreview] = useState<string | null>(null);
+  const [error, setError] = useState("");
 
   const handleClick = () => {
+    setError("");
     inputRef.current?.click();
   };
 
-  return (
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+
+    if (!file) return;
+
+    // 파일 타입, 크기 제한 검사
+    const isValidType = ["image/jpeg", "image/png"].includes(file.type);
+    const isValidSize = file.size <= 5 * 1024 * 1024;
+
+    if (!isValidType || !isValidSize) {
+      setError("유효하지 않은 파일입니다. JPG 또는 PNG 파일이며, 5MB 이하여야 합니다.");
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      setPreview(reader.result as string);
+    };
+    reader.readAsDataURL(file);
+  };
+
+  return preview ? (
+    <Preview preview={preview} setPreview={setPreview} />
+  ) : (
     <div
-      className="flex justify-center items-center border-2 border-dotted size-96 border-gray-600 rounded-xl bg-bg-primary transition-colors hover:bg-bg-secondary"
+      className="flex flex-col justify-center items-center border-2 border-dotted size-96 border-gray-600 rounded-xl bg-bg-primary transition-colors hover:bg-bg-secondary"
       onClick={handleClick}
     >
       <div className="flex flex-col justify-center items-center">
-        <Text variant="subText" className="text-center">
-          대표사진을 업로드해주세요.
-        </Text>
-        <Text variant="tooltip" className="text-center">
-          사진은 한 장, 5mb 이하, jpg 혹은 png 파일만 가능합니다.
-        </Text>
+        {error ? (
+          <Text variant="subText" className="text-error">
+            {error}
+          </Text>
+        ) : (
+          <>
+            <Text variant="subText" className="text-center">
+              대표사진을 업로드해주세요.
+            </Text>
+            <Text variant="tooltip" className="text-center">
+              사진은 한 장, 5mb 이하, jpg 혹은 png 파일만 가능합니다.
+            </Text>
+          </>
+        )}
       </div>
 
-      <input type="file" accept="image/*" className="hidden" ref={inputRef} />
+      <input
+        type="file"
+        accept="image/*"
+        className="hidden"
+        ref={inputRef}
+        onChange={handleChange}
+      />
+    </div>
+  );
+}
+
+interface PreviewProps {
+  preview: string;
+  setPreview: React.Dispatch<React.SetStateAction<string | null>>;
+}
+
+function Preview({ preview, setPreview }: PreviewProps) {
+  return (
+    <div className="flex flex-col justify-center items-center w-96 space-y-1">
+      <img src={preview} alt="preview-image" className="w-full object-contain rounded-xl" />
+      <Button
+        onClick={() => {
+          setPreview("");
+        }}
+      >
+        <Text variant="label" className="text-text-on-dark">
+          다른 사진 고르기
+        </Text>
+      </Button>
     </div>
   );
 }

--- a/src/components/input/ImageInput.tsx
+++ b/src/components/input/ImageInput.tsx
@@ -1,8 +1,9 @@
-import { useRef, useState } from "react";
+import { useRef, useState, type ComponentPropsWithRef } from "react";
 import Text from "@/components/text/Text";
 import Button from "@/components/Button";
+import clsx from "clsx";
 
-export default function ImageInput() {
+export default function ImageInput({ className, ...rest }: ComponentPropsWithRef<"input">) {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [preview, setPreview] = useState<string | null>(null);
   const [error, setError] = useState("");
@@ -37,7 +38,10 @@ export default function ImageInput() {
     <Preview preview={preview} setPreview={setPreview} />
   ) : (
     <div
-      className="flex flex-col justify-center items-center border-2 border-dotted size-96 border-gray-600 rounded-xl bg-bg-primary transition-colors hover:bg-bg-secondary"
+      className={clsx(
+        "flex flex-col justify-center items-center border-2 border-dotted size-96 border-gray-600 rounded-xl bg-bg-primary transition-colors hover:bg-bg-secondary",
+        className
+      )}
       onClick={handleClick}
     >
       <div className="flex flex-col justify-center items-center">
@@ -63,6 +67,7 @@ export default function ImageInput() {
         className="hidden"
         ref={inputRef}
         onChange={handleChange}
+        {...rest}
       />
     </div>
   );

--- a/src/components/input/ImageInput.tsx
+++ b/src/components/input/ImageInput.tsx
@@ -5,6 +5,8 @@ import clsx from "clsx";
 import { useDropzone } from "react-dropzone";
 
 interface ImageInputProps {
+  id?: string;
+  explanation?: string;
   className?: string;
   onChange?: (file: File | null) => void;
 }
@@ -13,7 +15,7 @@ interface ImageInputProps {
  * ref 중복 문제로 인해서 useForm의 register 함수로 등록 불가능.
  * 대신 useFrom의 setValue 함수를 onChange prop으로 등록하고 watch로 값 감시.
  */
-export default function ImageInput({ className, onChange }: ImageInputProps) {
+export default function ImageInput({ id, className, onChange, explanation }: ImageInputProps) {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [error, setError] = useState("");
 
@@ -79,14 +81,14 @@ export default function ImageInput({ className, onChange }: ImageInputProps) {
           ) : (
             <>
               <Text variant="subText" className="text-center">
-                대표사진을 업로드해주세요.
+                {explanation ? explanation : "대표사진을 업로드해주세요."}
               </Text>
               <Text variant="tooltip" className="text-center">
                 JPG, PNG / 5MB 이하
               </Text>
             </>
           )}
-          <input {...getInputProps()} className="hidden" />
+          <input {...getInputProps()} className="hidden" id={id} />
         </div>
       )}
     </div>

--- a/src/components/input/ImageInput.tsx
+++ b/src/components/input/ImageInput.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import Text from "@/components/text/Text";
 import Button from "@/components/Button";
 import clsx from "clsx";

--- a/src/components/input/ImageInput.tsx
+++ b/src/components/input/ImageInput.tsx
@@ -9,6 +9,10 @@ interface ImageInputProps {
   onChange?: (file: File | null) => void;
 }
 
+/**
+ * ref 중복 문제로 인해서 useForm의 register 함수로 등록 불가능.
+ * 대신 useFrom의 setValue 함수를 onChange prop으로 등록하고 watch로 값 감시.
+ */
 export default function ImageInput({ className, onChange }: ImageInputProps) {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [error, setError] = useState("");


### PR DESCRIPTION
## 📌 개요

이미지 인풋 컴포넌트 생성

## ✅ 작업 내용
- react-dropzone 설치
- 이미지 인풋 컴포넌트 생성
- 드래그 앤 드랍 가능
- jpg, png로 제약
- 5mb이하로 제약
- 프리뷰 기능


## ⚠️주의
- react-hook-form과 사용시 ref 중복 문제로 register 함수 사용 불가
- 대신 setValue 함수를 onChange prop으로 전달
- 주석 참고

## 🔍 관련 이슈

Closes #40

## 📸 스크린샷 (선택)
```jsx
<ImageInput explanation="프로필 사진을 업로드해주세요." />
```
### 사진 올리기 전
<img width="529" height="459" alt="Screenshot 2025-08-06 at 1 18 57 PM" src="https://github.com/user-attachments/assets/0f71528f-1af4-4aa6-88fd-11b9755f25aa" />

### 사진 프리뷰
<img width="448" height="338" alt="Screenshot 2025-08-06 at 1 19 17 PM" src="https://github.com/user-attachments/assets/adee1875-6cba-4147-bf2d-3dfa8184a4f6" />
