### PR TITLE
#57  positions 프로퍼티 PostDetail에서 Post로 이동

### DIFF
--- a/src/types/api-response.d.ts
+++ b/src/types/api-response.d.ts
@@ -56,10 +56,6 @@ interface PostDetail extends Post {
   recruitment_type: RecruitmentType;
   other_conditions: string;
   genres: Genre[];
-  positions: {
-    position: Position;
-    desired_experience_level: ExperienceLevel;
-  }[];
   is_owner: boolean;
   comments: Comment[];
 }
@@ -129,6 +125,10 @@ interface Post {
   views_count: number;
   comments_count: number;
   is_closed: boolean;
+  positions: {
+    position: Position;
+    desired_experience_level: ExperienceLevel;
+  }[];
 }
 interface Author {
   user_id: string;


### PR DESCRIPTION


## 📌 개요

 postions 프로퍼티 PostDetail에서 Post로 이동시켜서 PostList에서도 구인 포지션을 볼 수 있게 함

## ✅ 작업 내용

-  postions 프로퍼티 PostDetail에서 Post로 이동

## 🔍 관련 이슈

Closes #57 

## 📸 스크린샷 (선택)

변경사항이 UI에 영향을 주었다면 스크린샷을 포함해주세요.
