### PR TITLE
#85 공용 토글 버튼 제작

### DIFF
--- a/src/components/button/ToggleBtn.tsx
+++ b/src/components/button/ToggleBtn.tsx
@@ -1,23 +1,39 @@
 import { cn } from "@/libs/utils";
-import { useState } from "react";
+import { useState, type ComponentProps } from "react";
 
-interface ToggleBtnProps {
-  onToggle?: (isOn: boolean) => void;
+interface ToggleBtnProps extends ComponentProps<"button"> {
+  onToggleChange?: (isOn: boolean) => void;
   defaultOn?: boolean;
   className?: string;
 }
 
-export default function ToggleBtn({ onToggle, defaultOn = false, className }: ToggleBtnProps) {
+export default function ToggleBtn({
+  //토글상태 변경시 호출 함수
+  onToggleChange,
+  //컴포넌트 초기상태
+  defaultOn = false,
+  className,
+  ...props
+}: ToggleBtnProps) {
   const [isOn, setIsOn] = useState(defaultOn);
 
   const handleClick = () => {
-    const newState = !isOn;
-    setIsOn(newState);
-    onToggle?.(newState);
+    setIsOn((prev) => {
+      const newState = !prev;
+      //부모 컴포넌트로 상태 공유
+      onToggleChange?.(newState);
+      return newState;
+    });
   };
 
   return (
-    <button onClick={handleClick} className={cn("cursor-pointer", className)} aria-pressed={isOn}>
+    <button
+      onClick={handleClick}
+      className={cn("cursor-pointer", className)}
+      aria-pressed={isOn}
+      aria-label={isOn ? "활성화됨" : "비활성화됨"}
+      {...props}
+    >
       <svg xmlns="http://www.w3.org/2000/svg" width="64" height="24" viewBox="0 0 64 24">
         <rect
           width="64"


### PR DESCRIPTION
## 📌 개요

공용으로 사용할 수 있는 토글 버튼

## ✅ 작업 내용
- 공용으로 사용할 수 있게 로직 수정
- handleClick 함수 이전 상태 값 기반으로 작동하게 수정
- onToggle을 prop으로 진행시 에러 발생 => onToggleChange로 변경

## 🔍 관련 이슈

Closes #85 

## 📸 스크린샷 (선택)

변경사항이 UI에 영향을 주었다면 스크린샷을 포함해주세요.
<img width="175" height="78" alt="image" src="https://github.com/user-attachments/assets/d942c955-fb2e-4a20-b50a-f2d33c9947d9" />
