### PR TITLE
#78 모달

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@/libs/utils";
 import type { ComponentProps, ReactNode } from "react";
 
-interface ButtonProps extends ComponentProps<"button"> {
+export interface ButtonProps extends ComponentProps<"button"> {
   variant?: "default" | "outline";
   color?:
     | "primary"

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@/libs/utils";
 import type { ComponentProps, ReactNode } from "react";
 
-export interface ButtonProps extends ComponentProps<"button"> {
+interface ButtonProps extends ComponentProps<"button"> {
   variant?: "default" | "outline";
   color?:
     | "primary"

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 import { cn } from "@/libs/utils";
 import H3 from "./text/H3";
+import { HiOutlineX } from "react-icons/hi";
 
 /* --------------------
    Context
@@ -100,7 +101,7 @@ function ModalContent({ children, className, ...rest }: ModalContentProps) {
       >
         <div className="w-full flex items-center justify-end p-2">
           <H3 className="text-text-primary hover:cursor-pointer p-1" onClick={close}>
-            X
+            <HiOutlineX />
           </H3>
         </div>
         <div className="w-full p-4">{children}</div>

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -7,6 +7,9 @@ import {
   type ReactElement,
 } from "react";
 import { cn } from "@/libs/utils";
+import Button from "./Button";
+import Text from "./text/Text";
+import H3 from "./text/H3";
 
 /* --------------------
    Context
@@ -54,17 +57,30 @@ interface ModalContentProps extends ComponentProps<"div"> {
 }
 
 function ModalContent({ children, className, ...props }: ModalContentProps) {
-  const { isOpen } = useModalContext();
+  const { isOpen, toggle } = useModalContext();
+
+  if (!isOpen) return null;
+
   return (
     <div
       className={cn(
         isOpen ? "visible" : "hidden",
-        "p-5 border-neutral-600 border-2 absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2",
+        "flex flex-col  min-w-64 border-primary-soft bg-bg-primary border-2 absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2",
         className
       )}
       {...props}
     >
-      {children}
+      <div className="w-full flex items-center justify-end">
+        <H3
+          className=" text-text-primary hover:cursor-pointer p-1"
+          onClick={() => {
+            toggle();
+          }}
+        >
+          X
+        </H3>
+      </div>
+      <div className="w-full p-2">{children}</div>
     </div>
   );
 }

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -93,18 +93,20 @@ function ModalContent({ children, className, ...rest }: ModalContentProps) {
       {/* Modal */}
       <div
         className={cn(
-          "fixed z-50 flex flex-col min-w-64 border-primary-soft bg-bg-primary border-2 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-lg shadow-lg transition-all duration-200 transform",
+          "fixed z-50 p-2 pt-8 flex flex-col min-w-64 border-primary-soft bg-bg-primary border-2 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-lg shadow-lg transition-all duration-200 transform",
           isOpen ? "opacity-100 scale-100" : "opacity-0 scale-95",
           className
         )}
         {...rest}
       >
-        <div className="w-full flex items-center justify-end p-2">
-          <H3 className="text-text-primary hover:cursor-pointer p-1" onClick={close}>
-            <HiOutlineX />
-          </H3>
-        </div>
-        <div className="w-full p-4">{children}</div>
+        <H3
+          className="text-text-primary hover:cursor-pointer fixed top-1.5 right-1.5"
+          onClick={close}
+        >
+          <HiOutlineX />
+        </H3>
+
+        {children}
       </div>
     </>
   );

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,18 +1,93 @@
-import type { ComponentProps, ReactNode } from "react";
+import {
+  createContext,
+  useContext,
+  useState,
+  type ReactNode,
+  type ComponentProps,
+  type ReactElement,
+} from "react";
+import { cn } from "@/libs/utils";
 import Button from "./Button";
+import type { ButtonProps } from "./Button";
 
-interface ModalProps extends ComponentProps<"div"> {
-  buttonChildren: ReactNode;
+/* --------------------
+   Context
+-------------------- */
+interface ModalContextValue {
+  isOpen: boolean;
+  toggle: () => void;
+}
+
+const ModalContext = createContext<ModalContextValue | null>(null);
+
+function useModalContext() {
+  const ctx = useContext(ModalContext);
+  if (!ctx) throw new Error("Modal components must be used within <Modal>");
+  return ctx;
+}
+
+/* --------------------
+   1. Trigger
+-------------------- */
+interface ModalTriggerProps extends ButtonProps {
   children: ReactNode;
 }
 
-export default function Modal({ buttonChildren, children }: ModalProps) {
+function ModalTrigger({ children, ...rest }: ModalTriggerProps) {
+  const { toggle } = useModalContext();
   return (
-    <div>
-      <div>
-        <Button>{buttonChildren}</Button>
-      </div>
-      <div>{children}</div>
+    <Button
+      onClick={(e) => {
+        toggle();
+        rest.onClick?.(e);
+      }}
+      {...rest}
+    >
+      {children}
+    </Button>
+  );
+}
+
+/* --------------------
+   2. Content
+-------------------- */
+interface ModalContentProps extends ComponentProps<"div"> {
+  children: ReactNode;
+}
+
+function ModalContent({ children, className, ...props }: ModalContentProps) {
+  const { isOpen } = useModalContext();
+  return (
+    <div
+      className={cn(
+        isOpen ? "visible" : "hidden",
+        "size-10 border-neutral-600 border-2",
+        className
+      )}
+      {...props}
+    >
+      {children}
     </div>
   );
 }
+
+/* --------------------
+   3. Wrapper
+-------------------- */
+interface ModalProps {
+  children: [ReactElement<typeof ModalTrigger>, ReactElement<typeof ModalContent>];
+}
+
+function Modal({ children }: ModalProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggle = () => setIsOpen((prev) => !prev);
+
+  return (
+    <ModalContext.Provider value={{ isOpen, toggle }}>
+      <div>{children}</div>
+    </ModalContext.Provider>
+  );
+}
+
+export { Modal, ModalContent, ModalTrigger };

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -61,7 +61,7 @@ function ModalContent({ children, className, ...props }: ModalContentProps) {
     <div
       className={cn(
         isOpen ? "visible" : "hidden",
-        "size-10 border-neutral-600 border-2",
+        "p-5 border-neutral-600 border-2 absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2",
         className
       )}
       {...props}

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -69,7 +69,7 @@ function ModalContent({ children, className, ...props }: ModalContentProps) {
   return (
     <>
       {/* Overlay */}
-      <div className="fixed inset-0 bg-bg-primary/50 z-40" onClick={close} />
+      <div className="fixed inset-0 bg-bg-on-dark/50 z-40" onClick={close} />
 
       {/* Modal */}
       <div

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -113,7 +113,24 @@ function ModalContent({ children, className, ...rest }: ModalContentProps) {
 }
 
 /* --------------------
-   3. Wrapper
+   3. ModalClose
+-------------------- */
+
+interface ModalCloseProps {
+  children: ReactNode;
+}
+
+function ModalClose({ children, ...rest }: ModalCloseProps) {
+  const { close } = useModalContext();
+  return (
+    <div onClick={close} {...rest} className="hover:cursor-pointer">
+      {children}
+    </div>
+  );
+}
+
+/* --------------------
+   4. Wrapper
 -------------------- */
 interface ModalProps {
   children: [ReactElement<typeof ModalTrigger>, ReactElement<typeof ModalContent>];
@@ -145,4 +162,4 @@ function Modal({ children }: ModalProps) {
   );
 }
 
-export { Modal, ModalContent, ModalTrigger };
+export { Modal, ModalContent, ModalTrigger, ModalClose };

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -51,8 +51,20 @@ interface ModalContentProps extends ComponentProps<"div"> {
   children: ReactNode;
 }
 
-function ModalContent({ children, className, ...props }: ModalContentProps) {
+function ModalContent({ children, className, ...rest }: ModalContentProps) {
   const { isOpen, close } = useModalContext();
+  const [show, setShow] = useState(false);
+
+  // 모달 열릴 때 mount
+  useEffect(() => {
+    if (isOpen) {
+      setShow(true);
+    } else {
+      // 닫힘 애니메이션 시간만큼 지연 후 언마운트
+      const timer = setTimeout(() => setShow(false), 200); // 200ms = transition duration
+      return () => clearTimeout(timer);
+    }
+  }, [isOpen]);
 
   // ESC 키 닫기
   useEffect(() => {
@@ -64,28 +76,30 @@ function ModalContent({ children, className, ...props }: ModalContentProps) {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [isOpen, close]);
 
-  if (!isOpen) return null;
+  if (!show) return null;
 
   return (
     <>
       {/* Overlay */}
-      <div className="fixed inset-0 bg-bg-on-dark/50 z-40" onClick={close} />
+      <div
+        className={cn(
+          "fixed inset-0 bg-bg-on-dark/50 z-40 transition-opacity duration-200",
+          isOpen ? "opacity-100" : "opacity-0"
+        )}
+        onClick={close}
+      />
 
       {/* Modal */}
       <div
         className={cn(
-          "fixed z-50 flex flex-col min-w-64 border-primary-soft bg-bg-primary border-2 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-lg shadow-lg",
+          "fixed z-50 flex flex-col min-w-64 border-primary-soft bg-bg-primary border-2 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-lg shadow-lg transition-all duration-200 transform",
+          isOpen ? "opacity-100 scale-100" : "opacity-0 scale-95",
           className
         )}
-        {...props}
+        {...rest}
       >
         <div className="w-full flex items-center justify-end p-2">
-          <H3
-            className=" text-text-primary hover:cursor-pointer p-1"
-            onClick={() => {
-              close();
-            }}
-          >
+          <H3 className="text-text-primary hover:cursor-pointer p-1" onClick={close}>
             X
           </H3>
         </div>

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -32,7 +32,7 @@ function useModalContext() {
 /* --------------------
    1. Trigger
 -------------------- */
-interface ModalTriggerProps {
+interface ModalTriggerProps extends ComponentProps<"div"> {
   children: ReactNode;
 }
 
@@ -116,7 +116,7 @@ function ModalContent({ children, className, ...rest }: ModalContentProps) {
    3. ModalClose
 -------------------- */
 
-interface ModalCloseProps {
+interface ModalCloseProps extends ComponentProps<"div"> {
   children: ReactNode;
 }
 

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,18 @@
+import type { ComponentProps, ReactNode } from "react";
+import Button from "./Button";
+
+interface ModalProps extends ComponentProps<"div"> {
+  buttonChildren: ReactNode;
+  children: ReactNode;
+}
+
+export default function Modal({ buttonChildren, children }: ModalProps) {
+  return (
+    <div>
+      <div>
+        <Button>{buttonChildren}</Button>
+      </div>
+      <div>{children}</div>
+    </div>
+  );
+}

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -7,8 +7,6 @@ import {
   type ReactElement,
 } from "react";
 import { cn } from "@/libs/utils";
-import Button from "./Button";
-import type { ButtonProps } from "./Button";
 
 /* --------------------
    Context
@@ -29,22 +27,22 @@ function useModalContext() {
 /* --------------------
    1. Trigger
 -------------------- */
-interface ModalTriggerProps extends ButtonProps {
+interface ModalTriggerProps {
   children: ReactNode;
 }
 
 function ModalTrigger({ children, ...rest }: ModalTriggerProps) {
   const { toggle } = useModalContext();
   return (
-    <Button
-      onClick={(e) => {
+    <div
+      onClick={() => {
         toggle();
-        rest.onClick?.(e);
       }}
       {...rest}
+      className="hover:cursor-pointer"
     >
       {children}
-    </Button>
+    </div>
   );
 }
 


### PR DESCRIPTION
## 📌 개요

모달 컴포넌트 제작

## ✅ 작업 내용

- Modal, ModalTrigger, ModalContent, ModalClose가 합쳐진 복합 컴포넌트
- esc, 배경 클릭 시 모달 닫힘
- 아래 사용법을 잘 보고 사용!

### 참고코드
https://ui.shadcn.com/docs/components/dialog

### 사용법
1. Modal 관련 컴포넌트를 전부 Import
2. &lt;Modal&gt;안에 &lt;ModalTrigger&gt;와 &lt;ModalContent&gt;를 반드시 사용해야한다.
3. &lt;ModalTrigger&gt; 클릭 시 &lt;ModalContent&gt;가 화면에 나온다. 보통 버튼과 조합해서 사용하나 때에 따라 단순한 텍스트와도 사용 가능
4. &lt;ModalContent&gt;는 말 그대로  모달 안의 컨텐츠를 작성
5. &lt;ModalClose&gt;는 클릭 시 모달이 닫힘(필수 사용 아님)

## 🔍 관련 이슈

Closes #78 

## 📸 스크린샷 (선택)

### 사용예시
```jsx
    <div className="min-h-screen bg-bg-primary flex justify-center text-text-primary p-10">
      <Modal>
        <ModalTrigger>
          <Button variant="outline">
            <Text variant="label">댓글 삭제</Text>
          </Button>
        </ModalTrigger>
        <ModalContent className="flex flex-col space-y-1 px-5 w-72">
          <H2>삭제하시겠습니까?</H2>
          <p>
            <Text>해당 댓글을 삭제하시겠습니까?</Text>
          </p>
          <div className="flex w-full justify-end items-center space-x-1 mt-6">
            <ModalClose>
              <Button variant="outline" color="error" className="py-1">
                <Text variant="label">취소</Text>
              </Button>
            </ModalClose>
            <ModalClose>
              <Button variant="default" color="error" className="py-1">
                <Text variant="label" className="text-text-on-dark">
                  삭제
                </Text>
              </Button>
            </ModalClose>
          </div>
        </ModalContent>
      </Modal>
    </div>
```

### 모달 열기 전
<img width="961" height="939" alt="Screenshot 2025-08-08 at 3 08 39 PM" src="https://github.com/user-attachments/assets/7347134e-902e-42d8-9420-5307a69b247a" />

### 모달 연 후
<img width="966" height="1161" alt="Screenshot 2025-08-08 at 3 09 10 PM" src="https://github.com/user-attachments/assets/a4fc5bfe-544b-4940-ae3a-4fd2ebf31c1f" />
