### PR TITLE
#88 api created_at 타입 변경

### DIFF
--- a/src/components/RecruitmentCard.tsx
+++ b/src/components/RecruitmentCard.tsx
@@ -35,7 +35,7 @@ export default function RecruitmentCard({ postData }: RecruitmentCardProps) {
   const [timeDiff, setTimeDiff] = useState("");
 
   useEffect(() => {
-    setTimeDiff(getTimeDiff(createdAt));
+    setTimeDiff(getTimeDiff(new Date(createdAt)));
   }, [createdAt, setTimeDiff]);
 
   return (

--- a/src/types/api-res-recruitment.d.ts
+++ b/src/types/api-res-recruitment.d.ts
@@ -27,7 +27,7 @@ interface Post {
   author: Author;
   is_bookmarked: boolean;
   regions: Region[];
-  created_at: Date;
+  created_at: string;
   views_count: number;
   comments_count: number;
   bookmarks_count: number;


### PR DESCRIPTION
## 📌 개요

 api created_at 타입 Date에서 string으로 변경

## ✅ 작업 내용

-  api created_at 타입 Date에서 string으로 변경
- 기존 created_at 사용하는 코드 string을 Date로 파싱해서 사용하는 것으로 변경

## 🔍 관련 이슈

Closes #88 

## 📸 스크린샷 (선택)

변경사항이 UI에 영향을 주었다면 스크린샷을 포함해주세요.
