### PR TITLE
#79 코멘트 카드 컴포넌트 제작

### DIFF
--- a/src/components/CommentCard.tsx
+++ b/src/components/CommentCard.tsx
@@ -8,7 +8,7 @@ interface CommentCardProps {
   comment: CommentList["comments"][number];
 }
 
-// 오전/오후 00:00 포맷
+// "오전/오후 00:00" 형태의 시간 포맷 변환
 function formatTime(dateInput: Date | string): string {
   const date = new Date(dateInput);
   const hours = date.getHours();
@@ -20,7 +20,7 @@ function formatTime(dateInput: Date | string): string {
   return `${period} ${hour12}:${formattedMinutes}`;
 }
 
-// 2025년 08월 08일 포맷
+// "YYYY년 MM월 DD일" 형태의 날짜 포맷 변환
 function formatDate(dateInput: Date | string): string {
   const date = new Date(dateInput);
   const year = date.getFullYear();

--- a/src/components/CommentCard.tsx
+++ b/src/components/CommentCard.tsx
@@ -31,12 +31,18 @@ function formatDate(dateInput: Date | string): string {
 }
 
 export default function CommentCard({ comment }: CommentCardProps) {
-  const time = formatTime(comment.created_at);
-  const date = formatDate(comment.created_at);
+  const {
+    content,
+    created_at: createdAt,
+    post: { id: postId, title: postTitle },
+  } = comment;
+
+  const time = formatTime(createdAt);
+  const date = formatDate(createdAt);
 
   return (
     <Link
-      to={`/recruiting-posts/${comment.post.id}`}
+      to={`/recruiting-posts/${postId}`}
       className={clsx(
         "relative block rounded-xl p-4",
         "border-2 bg-bg-primary border-primary-soft",
@@ -50,15 +56,18 @@ export default function CommentCard({ comment }: CommentCardProps) {
       </Text>
 
       {/* 댓글 본문 */}
-      <H3 className="text-sm mb-2 line-clamp-2 text-text-primary">{comment.content}</H3>
+      <H3 className="text-sm mb-2 line-clamp-2 text-text-primary">{content}</H3>
 
       {/* 연결된 게시글 제목 */}
       <Text variant="subText" className="text-text-primary">
-        게시글: {comment.post.title}
+        게시글: {postTitle}
       </Text>
 
       {/* 작성일 우측 하단 표시 */}
-      <Text variant="tooltip" className="absolute bottom-2 right-4 text-xs text-gray-400">
+      <Text
+        variant="tooltip"
+        className="absolute bottom-2 right-4 text-xs text-text-primary opacity-50"
+      >
         {date}
       </Text>
     </Link>

--- a/src/components/CommentCard.tsx
+++ b/src/components/CommentCard.tsx
@@ -1,0 +1,66 @@
+import { Link } from "react-router-dom";
+import clsx from "clsx";
+import H3 from "@/components/text/H3";
+import Text from "@/components/text/Text";
+import type { CommentList } from "@/types/api-res-comment";
+
+interface CommentCardProps {
+  comment: CommentList["comments"][number];
+}
+
+// 오전/오후 00:00 포맷
+function formatTime(dateInput: Date | string): string {
+  const date = new Date(dateInput);
+  const hours = date.getHours();
+  const minutes = date.getMinutes();
+  const period = hours >= 12 ? "오후" : "오전";
+  const hour12 = hours % 12 || 12;
+  const formattedMinutes = minutes.toString().padStart(2, "0");
+
+  return `${period} ${hour12}:${formattedMinutes}`;
+}
+
+// 2025년 08월 08일 포맷
+function formatDate(dateInput: Date | string): string {
+  const date = new Date(dateInput);
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getDate()}`.padStart(2, "0");
+
+  return `${year}년 ${month}월 ${day}일`;
+}
+
+export default function CommentCard({ comment }: CommentCardProps) {
+  const time = formatTime(comment.created_at);
+  const date = formatDate(comment.created_at);
+
+  return (
+    <Link
+      to={`/recruiting-posts/${comment.post.id}`}
+      className={clsx(
+        "relative block rounded-xl p-4",
+        "border-2 bg-bg-primary border-primary-soft",
+        "hover:bg-bg-secondary",
+        "transition-colors duration-300 ease-in-out"
+      )}
+    >
+      {/* 작성 시간 */}
+      <Text variant="tooltip" className="text-text-primary mb-1">
+        {time}
+      </Text>
+
+      {/* 댓글 본문 */}
+      <H3 className="text-sm mb-2 line-clamp-2 text-text-primary">{comment.content}</H3>
+
+      {/* 연결된 게시글 제목 */}
+      <Text variant="subText" className="text-text-primary">
+        게시글: {comment.post.title}
+      </Text>
+
+      {/* 작성일 우측 하단 표시 */}
+      <Text variant="tooltip" className="absolute bottom-2 right-4 text-xs text-gray-400">
+        {date}
+      </Text>
+    </Link>
+  );
+}

--- a/src/types/api-res-comment.d.ts
+++ b/src/types/api-res-comment.d.ts
@@ -16,4 +16,5 @@ export interface Comment {
   content: string;
   is_owner: boolean;
   children: Comment[];
+  created_at: string;
 }


### PR DESCRIPTION
## 📌 개요

코멘트 카드 컴포넌트 제작
## ✅ 작업 내용

- 코멘트 카드 클릭 시 해당 댓글을 적은 게시글로 가게 끔 링크
- 날짜, 시간, 내가 쓴 댓글, 내가 댓글을 쓴 게시글 표시

## 🔍 관련 이슈

Closes #79 

## 📸 스크린샷 (선택)

실제 화면
<img width="914" height="715" alt="스크린샷 2025-08-08 154153" src="https://github.com/user-attachments/assets/a0ef0810-c78a-4a55-8af5-3086435c6c64" />

사용 예시
<img width="733" height="413" alt="스크린샷 2025-08-08 154830" src="https://github.com/user-attachments/assets/7cbec916-f15e-413e-8c17-5fe813218120" />

