### PR TITLE
#94 linkbutton 공용button에 추가

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,8 +1,9 @@
 import { cn } from "@/libs/utils";
-import type { ComponentProps, ReactNode } from "react";
+import type { ComponentProps, ElementType, ReactNode } from "react";
 
-interface ButtonProps extends ComponentProps<"button"> {
-  variant?: "default" | "outline";
+interface ButtonProps<T extends ElementType = "button"> {
+  as?: T;
+  variant?: "default" | "outline" | "link-primary" | "link-secondary";
   color?:
     | "primary"
     | "primary-thick"
@@ -11,8 +12,11 @@ interface ButtonProps extends ComponentProps<"button"> {
     | "secondary-thick"
     | "secondary-soft"
     | "error"
-    | "neutral";
+    | "neutral"
+    | "neutral-soft";
   children: ReactNode;
+  className?: string;
+  to?: string;
 }
 
 const getVariantClasses = (variant: ButtonProps["variant"], color: ButtonProps["color"]) => {
@@ -26,7 +30,20 @@ const getVariantClasses = (variant: ButtonProps["variant"], color: ButtonProps["
       "border-secondary-soft": color === "secondary-soft",
       "border-error": color === "error",
       "border-neutral-600": color === "neutral",
+      "border-neutral-300": color === "neutral-soft",
     });
+  }
+
+  if (variant === "link-primary") {
+    return cn(
+      "bg-primary-thick text-text-on-dark border-transparent hover:bg-white hover:border-1 hover:text-text-primary hover:border-primary-thick"
+    );
+  }
+
+  if (variant === "link-secondary") {
+    return cn(
+      "bg-white border border-transparent hover:text-text-primary hover:border-1 hover:border-primary-thick"
+    );
   }
 
   return cn({
@@ -38,26 +55,30 @@ const getVariantClasses = (variant: ButtonProps["variant"], color: ButtonProps["
     "bg-secondary-soft": color === "secondary-soft",
     "bg-error": color === "error",
     "bg-neutral-600": color === "neutral",
+    "bg-neutral-300": color === "neutral-soft",
   });
 };
 
-export default function Button({
+export default function Button<T extends ElementType = "button">({
+  as,
   variant = "default",
   color = "primary",
   className,
   children,
   ...rest
-}: ButtonProps) {
+}: ButtonProps<T> & Omit<ComponentProps<T>, keyof ButtonProps>) {
+  const Component = as || "button";
+
   return (
-    <button
+    <Component
       className={cn(
-        "px-5 py-2 rounded-xl transition-all active:scale-95 hover:cursor-pointer hover:scale-105 focus:outline-none",
+        "flex items-center justify-center px-6 py-2 rounded-md transition-all active:scale-95 hover:cursor-pointer hover:scale-105 focus:outline-none duration-300 ease-in-out",
         getVariantClasses(variant, color),
         className
       )}
       {...rest}
     >
       {children}
-    </button>
+    </Component>
   );
 }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,9 +1,8 @@
 import { cn } from "@/libs/utils";
-import type { ComponentProps, ElementType, ReactNode } from "react";
+import type { ComponentProps, ReactNode } from "react";
 
-interface ButtonProps<T extends ElementType = "button"> {
-  as?: T;
-  variant?: "default" | "outline" | "link-primary" | "link-secondary";
+interface ButtonProps extends ComponentProps<"button"> {
+  variant?: "default" | "outline";
   color?:
     | "primary"
     | "primary-thick"
@@ -16,7 +15,6 @@ interface ButtonProps<T extends ElementType = "button"> {
     | "neutral-soft";
   children: ReactNode;
   className?: string;
-  to?: string;
 }
 
 const getVariantClasses = (variant: ButtonProps["variant"], color: ButtonProps["color"]) => {
@@ -34,18 +32,6 @@ const getVariantClasses = (variant: ButtonProps["variant"], color: ButtonProps["
     });
   }
 
-  if (variant === "link-primary") {
-    return cn(
-      "bg-primary-thick text-text-on-dark border-transparent hover:bg-white hover:border-1 hover:text-text-primary hover:border-primary-thick"
-    );
-  }
-
-  if (variant === "link-secondary") {
-    return cn(
-      "bg-white border border-transparent hover:text-text-primary hover:border-1 hover:border-primary-thick"
-    );
-  }
-
   return cn({
     "bg-primary": color === "primary",
     "bg-primary-thick": color === "primary-thick",
@@ -59,18 +45,15 @@ const getVariantClasses = (variant: ButtonProps["variant"], color: ButtonProps["
   });
 };
 
-export default function Button<T extends ElementType = "button">({
-  as,
+export default function Button({
   variant = "default",
   color = "primary",
   className,
   children,
   ...rest
-}: ButtonProps<T> & Omit<ComponentProps<T>, keyof ButtonProps>) {
-  const Component = as || "button";
-
+}: ButtonProps) {
   return (
-    <Component
+    <button
       className={cn(
         "flex items-center justify-center px-6 py-2 rounded-md transition-all active:scale-95 hover:cursor-pointer hover:scale-105 focus:outline-none duration-300 ease-in-out",
         getVariantClasses(variant, color),
@@ -79,6 +62,6 @@ export default function Button<T extends ElementType = "button">({
       {...rest}
     >
       {children}
-    </Component>
+    </button>
   );
 }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -2,7 +2,7 @@ import { cn } from "@/libs/utils";
 import type { ComponentProps, ReactNode } from "react";
 
 interface ButtonProps extends ComponentProps<"button"> {
-  variant?: "default" | "outline";
+  variant?: "default" | "outline" | "link-primary" | "link-secondary";
   color?:
     | "primary"
     | "primary-thick"
@@ -30,6 +30,18 @@ const getVariantClasses = (variant: ButtonProps["variant"], color: ButtonProps["
       "border-neutral-600": color === "neutral",
       "border-neutral-300": color === "neutral-soft",
     });
+  }
+
+  if (variant === "link-primary") {
+    return cn(
+      "bg-primary-thick text-text-on-dark border-transparent hover:bg-white hover:border-1 hover:text-text-primary hover:border-primary-thick"
+    );
+  }
+
+  if (variant === "link-secondary") {
+    return cn(
+      "bg-white border border-transparent hover:text-text-primary hover:border-1 hover:border-primary-thick"
+    );
   }
 
   return cn({


### PR DESCRIPTION
## 📌 개요

- inkbutton 공용button에 추가

## ✅ 작업 내용

- as: T prop 추가 (as={Link}작성시 link컴포넌트로 사용가능)
- variant prop 에 link-primary, link-secondary추가
- link컴포넌트 렌더링 할때 필요한 to prop추가
- natural-soft 색상 추가
- 
## 🔍 관련 이슈

Closes #94

## 📸 스크린샷 (선택)

변경사항이 UI에 영향을 주었다면 스크린샷을 포함해주세요.
