### PR TITLE
 #95 feature/스켈레톤 카드 3종( 구인글, 프로필, 댓글) 및 로딩 인디케이터

### DIFF
--- a/src/components/loading/InlineSpinner.tsx
+++ b/src/components/loading/InlineSpinner.tsx
@@ -1,0 +1,18 @@
+import type { ComponentPropsWithoutRef } from "react";
+import { cn } from "@/libs/utils";
+import Text from "@/components/text/Text";
+
+export default function InlineSpinner({ className, ...rest }: ComponentPropsWithoutRef<"div">) {
+  return (
+    <div className={cn("inline-flex items-center gap-2", className)} {...rest}>
+      <div
+        className={cn(
+          "h-5 w-5 rounded-full border-2 border-current border-t-transparent",
+          "animate-spin motion-reduce:animate-none"
+        )}
+        aria-hidden="true"
+      />
+      <Text className="sr-only">로딩 중</Text>
+    </div>
+  );
+}

--- a/src/components/loading/LoadingOverlay.tsx
+++ b/src/components/loading/LoadingOverlay.tsx
@@ -1,0 +1,14 @@
+import InlineSpinner from "./InlineSpinner";
+
+export default function LoadingOverlay() {
+  return (
+    <div
+      className="absolute inset-0 z-10 flex items-center justify-center bg-white/60 dark:bg-black/30 backdrop-blur-sm"
+      role="status"
+      aria-busy="true"
+      aria-label="로딩 중"
+    >
+      <InlineSpinner className="text-primary" />
+    </div>
+  );
+}

--- a/src/components/skeletons/CommentCardSkeleton.tsx
+++ b/src/components/skeletons/CommentCardSkeleton.tsx
@@ -1,0 +1,15 @@
+import SkeletonText from "@/components/ui/SkeletonText";
+
+export default function CommentCardSkeleton() {
+  return (
+    <div className="relative block rounded-xl p-4 border-2 bg-bg-primary border-primary-soft max-w-96">
+      {/* 시간 */}
+      <SkeletonText variant="tooltip" className="w-24 mb-2" />
+      {/* 본문 2줄 */}
+      <SkeletonText variant="h3" className="w-4/5 mb-2" />
+      <SkeletonText variant="subText" className="w-2/3" />
+      {/* 우하단 날짜 */}
+      <SkeletonText variant="tooltip" className="w-20 absolute bottom-2 right-4" />
+    </div>
+  );
+}

--- a/src/components/skeletons/Loaders.tsx
+++ b/src/components/skeletons/Loaders.tsx
@@ -1,0 +1,33 @@
+import RecruitingPostCardSkeleton from "./RecruitmentCardSkeleton";
+import ProfileCardSkeleton from "./ProfileCardSkeleton";
+import CommentItemSkeleton from "./CommentCardSkeleton";
+
+export function RecruitingPostListLoading({ count = 6 }: { count?: number }) {
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:gap-5">
+      {Array.from({ length: count }).map((_, i) => (
+        <RecruitingPostCardSkeleton key={i} />
+      ))}
+    </div>
+  );
+}
+
+export function ProfileListLoading({ count = 6 }: { count?: number }) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-5">
+      {Array.from({ length: count }).map((_, i) => (
+        <ProfileCardSkeleton key={i} />
+      ))}
+    </div>
+  );
+}
+
+export function CommentListLoading({ count = 5 }: { count?: number }) {
+  return (
+    <div className="flex flex-col gap-4">
+      {Array.from({ length: count }).map((_, i) => (
+        <CommentItemSkeleton key={i} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/skeletons/ProfileCardSkeleton.tsx
+++ b/src/components/skeletons/ProfileCardSkeleton.tsx
@@ -1,0 +1,45 @@
+import Skeleton from "@/components/ui/Skeleton";
+import SkeletonText from "@/components/ui/SkeletonText";
+
+export default function ProfileCardSkeleton() {
+  return (
+    <div className="relative w-80 rounded-xl bg-bg-secondary px-4 pt-2 pb-5 border border-gray-300 shadow-sm">
+      <div className="flex items-center justify-between gap-2">
+        {/* 좌: 아바타 */}
+        <Skeleton className="w-12 h-12 rounded-full" />
+
+        {/* 중앙: 닉네임 */}
+        <div className="flex-1 text-center">
+          <SkeletonText variant="h2" className="w-24 mx-auto" />
+        </div>
+
+        {/* 우: 북마크 */}
+        <Skeleton className="h-6 w-6 rounded" />
+      </div>
+
+      <div className="flex items-center gap-4 mt-4">
+        <div className="flex items-center gap-2">
+          <SkeletonText variant="label" className="w-10" />
+          <Skeleton className="h-5 w-12 rounded-full" />
+        </div>
+        <div className="flex items-center gap-2">
+          <SkeletonText variant="label" className="w-10" />
+          <SkeletonText variant="label" className="w-12" />
+        </div>
+      </div>
+
+      <div className="mt-3 flex gap-4">
+        <SkeletonText variant="label" className="w-16 mb-2" />
+        <div className="flex gap-2 flex-wrap">
+          <Skeleton className="h-5 w-16 rounded-full" />
+          <Skeleton className="h-5 w-16 rounded-full" />
+        </div>
+      </div>
+
+      <div className="mt-4 flex gap-4 text-center">
+        <SkeletonText variant="label" className="w-16 mb-2" />
+        <SkeletonText variant="subText" className="w-40 mb-2" />
+      </div>
+    </div>
+  );
+}

--- a/src/components/skeletons/RecruitmentCardSkeleton.tsx
+++ b/src/components/skeletons/RecruitmentCardSkeleton.tsx
@@ -1,0 +1,69 @@
+import Skeleton from "@/components/ui/Skeleton";
+import SkeletonText from "@/components/ui/SkeletonText";
+import { cn } from "@/libs/utils";
+
+export default function RecruitmentCardSkeleton() {
+  return (
+    <div
+      className={cn(
+        "block min-w-0 relative isolate overflow-hidden",
+        "rounded-xl border border-gray-300 bg-bg-secondary p-5 text-text-primary shadow-sm",
+        "w-full max-w-96"
+      )}
+      role="status"
+      aria-busy="true"
+      aria-label="로딩 중"
+    >
+      {/* 헤더: 제목 + 북마크 */}
+      <div className="flex w-full items-center gap-3">
+        <SkeletonText variant="h3" className="flex-1 min-w-0" />
+        <Skeleton className="h-6 w-6 shrink-0 rounded" />
+      </div>
+
+      {/* 배지 / 작성자·시간 */}
+      <div className="mt-2 mb-3 flex w-full items-center justify-between">
+        <Skeleton className="h-6 w-16 rounded-full" />
+        <div className="flex items-center gap-2">
+          <SkeletonText variant="subText" className="w-20" />
+          <SkeletonText variant="subText" className="w-10" />
+        </div>
+      </div>
+
+      {/* 본문 */}
+      <div className="flex w-full flex-col gap-4 sm:flex-row min-w-0">
+        <div className="flex flex-1 min-w-0 flex-col gap-2">
+          <div className="flex items-center gap-2">
+            <SkeletonText variant="mainText" className="w-12" />
+            <Skeleton className="h-5 w-12 rounded-full" />
+            <Skeleton className="h-5 w-12 rounded-full" />
+            <Skeleton className="h-5 w-12 rounded-full" />
+          </div>
+          <div className="flex items-center gap-2">
+            <SkeletonText variant="mainText" className="w-10" />
+            <Skeleton className="h-5 w-14 rounded-full" />
+            <Skeleton className="h-5 w-14 rounded-full" />
+            <Skeleton className="h-5 w-14 rounded-full" />
+          </div>
+          <div className="flex items-center gap-2">
+            <SkeletonText variant="mainText" className="w-16" />
+            <Skeleton className="h-5 w-16 rounded-full" />
+            <Skeleton className="h-5 w-16 rounded-full" />
+          </div>
+          <div className="flex items-center gap-2">
+            <SkeletonText variant="mainText" className="w-10" />
+            <Skeleton className="h-5 w-12 rounded-full" />
+          </div>
+        </div>
+
+        {/* 우측 메타 */}
+        <div className="flex flex-col items-end justify-end pr-1">
+          <div className="flex items-center gap-3">
+            <SkeletonText variant="subText" className="w-10" />
+            <SkeletonText variant="subText" className="w-10" />
+            <SkeletonText variant="subText" className="w-10" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -1,0 +1,31 @@
+import type { ComponentPropsWithoutRef } from "react";
+import { cn } from "@/libs/utils";
+
+type Tone = "soft" | "contrast";
+
+interface Props extends ComponentPropsWithoutRef<"div"> {
+  tone?: Tone; // 배경 대비
+  anim?: boolean;
+}
+
+/** 공통 스켈레톤 바 */
+export default function Skeleton({ className, tone = "contrast", anim = true, ...rest }: Props) {
+  const toneClass =
+    tone === "contrast" ? "bg-gray-300 dark:bg-gray-600" : "bg-gray-200/80 dark:bg-gray-700/50";
+
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      className={cn(
+        "relative overflow-hidden rounded-md",
+        "animate-pulse motion-reduce:before:animate-none",
+        toneClass,
+        anim &&
+          'before:content-[""] before:absolute before:inset-0 before:-translate-x-full before:animate-[shimmer_1.4s_ease_infinite] before:bg-gradient-to-r before:from-transparent before:via-white/60 dark:before:via-white/10 before:to-transparent',
+        className
+      )}
+      {...rest}
+    />
+  );
+}

--- a/src/components/ui/SkeletonText.tsx
+++ b/src/components/ui/SkeletonText.tsx
@@ -1,0 +1,24 @@
+import type { ComponentPropsWithoutRef } from "react";
+import { cn } from "@/libs/utils";
+import Skeleton from "./Skeleton";
+
+/** 네가 쓰는 타이포(H1/H2/H3/Text.variant) 높이에 맞춘 텍스트 스켈레톤 */
+type Variant = "h1" | "h2" | "h3" | "mainText" | "subText" | "label" | "tooltip" | "button";
+
+const map: Record<Variant, string> = {
+  h1: "h-8 sm:h-10 rounded",
+  h2: "h-7 sm:h-9 rounded",
+  h3: "h-6 sm:h-8 rounded",
+  mainText: "h-5 rounded",
+  subText: "h-4 sm:h-5 rounded",
+  label: "h-4 rounded",
+  tooltip: "h-3 rounded",
+  button: "h-4 rounded",
+};
+
+interface Props extends Omit<ComponentPropsWithoutRef<"div">, "children"> {
+  variant: Variant;
+}
+export default function SkeletonText({ variant, className, ...rest }: Props) {
+  return <Skeleton className={cn(map[variant], className)} {...rest} />;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -36,3 +36,13 @@ body {
   font-weight: 400;
   font-style: normal;
 }
+
+@keyframes sk-breath {
+  0%,
+  100% {
+    opacity: 0.85;
+  }
+  50% {
+    opacity: 0.45;
+  }
+}


### PR DESCRIPTION
## 📌 개요

로딩 인디케이터 및 스켈레톤 카드 3종 구현 

## ✅ 작업 내용

- 320px 까지 형태가 유지되게끔 반응형으로 작업
- 스켈레톤 카드에 자연스레 색이 바뀌는 애니메이션 추가
- 각 카드에 맞게 스켈레톤 카드 컴포넌트 개별로 제작

## 🔍 관련 이슈

Closes #95 

## 📸 스크린샷 (선택)

<img width="791" height="835" alt="스크린샷 2025-08-11 170701" src="https://github.com/user-attachments/assets/9dece86a-f260-4e97-840f-ae7284c94aed" />
<img width="339" height="374" alt="스크린샷 2025-08-11 170707" src="https://github.com/user-attachments/assets/20f58d90-f5b5-4738-968b-e2622b9ba87b" />

