### PR TITLE
#96 구인글 리스트, 프로필 리스트 필터

### DIFF
--- a/src/components/Filter.tsx
+++ b/src/components/Filter.tsx
@@ -189,10 +189,7 @@ function FilterSection({ title, data, queryKey, mode = "multi" }: FilterSectionP
                 e.preventDefault();
                 toggleValue(item.id);
               }}
-              className={cn(
-                "cursor-pointer ",
-                isSelected(item.id) ? " hover:bg-primary-soft" : "hover:bg-primary"
-              )}
+              className={cn("cursor-pointer ", isSelected(item.id) ? "" : "hover:bg-primary")}
             >
               {item.name}
             </Badge>

--- a/src/components/Filter.tsx
+++ b/src/components/Filter.tsx
@@ -74,9 +74,14 @@ const MOBILE_SIZE_PX = 640;
 interface FilterProps {
   filterType: "profileFilter" | "recruitmentPostFilter";
   breakPointPX?: number; //접었다 폈다 가능하게 하는 px(기본값은 640(tailwind의 sm 사이즈))
+  className?: string;
 }
 
-export default function Filter({ filterType, breakPointPX = MOBILE_SIZE_PX }: FilterProps) {
+export default function Filter({
+  filterType,
+  breakPointPX = MOBILE_SIZE_PX,
+  className = "",
+}: FilterProps) {
   //마스터 데이터 실제론 api로 받기
   const {
     regions,
@@ -128,7 +133,9 @@ export default function Filter({ filterType, breakPointPX = MOBILE_SIZE_PX }: Fi
   }, [windowWidth, breakPointPX]);
 
   return (
-    <div className="flex flex-col border-2 border-neutral-600 rounded-xl max-w-sm p-2">
+    <div
+      className={cn("flex flex-col border-2 border-neutral-600 rounded-xl max-w-sm p-2", className)}
+    >
       <div className="flex items-center justify-between space-x-1.5 px-1">
         <BsFillFunnelFill
           onClick={handleFilterClick}

--- a/src/components/Filter.tsx
+++ b/src/components/Filter.tsx
@@ -1,4 +1,6 @@
 import { BsFillFunnelFill } from "react-icons/bs";
+import Badge from "@/components/Badge";
+import Text from "@/components/text/Text";
 
 //마스터 데이터 실제론 api로 받기
 const MASTER_DATA: MasterData = {
@@ -61,18 +63,23 @@ const MASTER_DATA: MasterData = {
   recruiting_post_types: [],
 };
 
-interface FilterProps {}
+interface FilterProps {
+  filterType: "profileFilter" | "recruitmentPostFilter";
+}
 
-export default function Filter({}: FilterProps) {
+export default function Filter({ filterType }: FilterProps) {
   //마스터 데이터 실제론 api로 받기
   const {
     regions,
     positions,
     genres,
-    experience_levels: experienceLevel,
+    experience_levels: experienceLevels,
     orientations,
     recruitment_types: recruitmentTypes,
   } = MASTER_DATA;
+
+  const orders = ["최신순", "댓글순", "인기순"];
+  const bookmarks = ["전부", "북마크만"];
 
   return (
     <div className="flex flex-col border-2 border-neutral-600 rounded-xl max-w-sm p-2">
@@ -80,6 +87,52 @@ export default function Filter({}: FilterProps) {
         <BsFillFunnelFill size={24} />
         <input className="rounded-full bg-bg-on-dark text-text-on-dark px-3 py-0.5 focus:outline-none flex-1" />
       </div>
+      <div className="flex flex-col space-y-2">
+        <FilterSection title={"순서"} data={orders} />
+        <FilterSection title={"북마크"} data={bookmarks} />
+        <FilterSection title={"지역"} data={regions} />
+        <FilterSection title={"선호 장르"} data={genres} />
+        <FilterSection title={"포지션"} data={positions} />
+        <FilterSection
+          title={filterType === "recruitmentPostFilter" ? "요구 경력" : "경력"}
+          data={experienceLevels}
+        />
+        <FilterSection title={"지향"} data={orientations} />
+        {filterType === "recruitmentPostFilter" ? (
+          <FilterSection title={"밴드 타입"} data={recruitmentTypes} />
+        ) : null}
+      </div>
     </div>
+  );
+}
+
+interface FilterSectionProps {
+  title: string;
+  data:
+    | {
+        id: string;
+        name: string;
+      }[]
+    | string[];
+}
+
+function FilterSection({ title, data }: FilterSectionProps) {
+  return (
+    <section className="flex flex-col items-start space-y-1">
+      <Text variant="mainText">{title}</Text>
+      <div className="flex flex-wrap items-start justify-start gap-0.5">
+        {data.map((data, i) => (
+          <Badge
+            color="primarySoft"
+            size="sm"
+            textVariant="label"
+            key={typeof data === "string" ? i : data.id}
+            className="cursor-pointer hover:bg-primary"
+          >
+            {typeof data === "string" ? data : data.name}
+          </Badge>
+        ))}
+      </div>
+    </section>
   );
 }

--- a/src/components/Filter.tsx
+++ b/src/components/Filter.tsx
@@ -1,0 +1,5 @@
+interface FilterProps {}
+
+export default function Filter({}: FilterProps) {
+  return <div>Filter</div>;
+}

--- a/src/components/Filter.tsx
+++ b/src/components/Filter.tsx
@@ -3,7 +3,9 @@ import Badge from "@/components/Badge";
 import Text from "@/components/text/Text";
 import { useSearchParams } from "react-router";
 import { cn } from "@/libs/utils";
-import { useSelectQuery } from "@/hooks/useSelectQuery";
+import useSelectQuery from "@/hooks/useSelectQuery";
+import useWindowWidth from "@/hooks/useWindowWidth";
+import { useEffect, useState } from "react";
 
 //마스터 데이터 실제론 api로 받기
 const MASTER_DATA: MasterData = {
@@ -67,12 +69,14 @@ const MASTER_DATA: MasterData = {
 };
 
 const SEARCH_QUERY_KEY = "search_query";
+const MOBILE_SIZE_PX = 640;
 
 interface FilterProps {
   filterType: "profileFilter" | "recruitmentPostFilter";
+  breakPointPX?: number; //접었다 폈다 가능하게 하는 px(기본값은 640(tailwind의 sm 사이즈))
 }
 
-export default function Filter({ filterType }: FilterProps) {
+export default function Filter({ filterType, breakPointPX = MOBILE_SIZE_PX }: FilterProps) {
   //마스터 데이터 실제론 api로 받기
   const {
     regions,
@@ -104,10 +108,33 @@ export default function Filter({ filterType }: FilterProps) {
     setSearchParams("");
   };
 
+  const windowWidth = useWindowWidth();
+
+  const [isVisible, setIsVisible] = useState(false);
+
+  const handleFilterClick: React.MouseEventHandler<SVGElement> = (e) => {
+    e.preventDefault();
+    if (windowWidth >= breakPointPX) return;
+
+    setIsVisible(!isVisible);
+  };
+
+  useEffect(() => {
+    if (windowWidth >= breakPointPX) {
+      setIsVisible(true);
+    } else {
+      setIsVisible(false);
+    }
+  }, [windowWidth, breakPointPX]);
+
   return (
     <div className="flex flex-col border-2 border-neutral-600 rounded-xl max-w-sm p-2">
       <div className="flex items-center justify-between space-x-1.5 px-1">
-        <BsFillFunnelFill size={24} className="cursor-pointer sm:cursor-default flex-shrink-0" />
+        <BsFillFunnelFill
+          onClick={handleFilterClick}
+          size={24}
+          className="cursor-pointer sm:cursor-default flex-shrink-0"
+        />
         <input
           onChange={handleInputChange}
           className="rounded-full bg-bg-on-dark text-text-on-dark px-3 py-0.5 focus:outline-none flex-1 min-w-0"
@@ -118,7 +145,7 @@ export default function Filter({ filterType }: FilterProps) {
           onClick={handleInitializeClick}
         />
       </div>
-      <div className="flex flex-col space-y-2">
+      <div className={cn("flex flex-col space-y-2", isVisible ? "visible" : "hidden")}>
         <FilterSection queryKey="sort_by" title={"순서"} data={orders} mode="single" />
         <FilterSection queryKey="bookmark" title={"북마크"} data={bookmarks} mode="single" />
         <FilterSection queryKey="region_ids" title={"지역"} data={regions} />

--- a/src/components/Filter.tsx
+++ b/src/components/Filter.tsx
@@ -1,4 +1,4 @@
-import { BsFillFunnelFill } from "react-icons/bs";
+import { BsFillFunnelFill, BsArrowCounterclockwise } from "react-icons/bs";
 import Badge from "@/components/Badge";
 import Text from "@/components/text/Text";
 import { useSearchParams } from "react-router";
@@ -100,6 +100,10 @@ export default function Filter({ filterType }: FilterProps) {
     setSearchParams(searchParams);
   };
 
+  const handleInitializeClick = () => {
+    setSearchParams("");
+  };
+
   return (
     <div className="flex flex-col border-2 border-neutral-600 rounded-xl max-w-sm p-2">
       <div className="flex items-center justify-between space-x-1.5 px-1">
@@ -107,6 +111,11 @@ export default function Filter({ filterType }: FilterProps) {
         <input
           onChange={handleInputChange}
           className="rounded-full bg-bg-on-dark text-text-on-dark px-3 py-0.5 focus:outline-none flex-1"
+        />
+        <BsArrowCounterclockwise
+          size={24}
+          className="cursor-pointer"
+          onClick={handleInitializeClick}
         />
       </div>
       <div className="flex flex-col space-y-2">

--- a/src/components/Filter.tsx
+++ b/src/components/Filter.tsx
@@ -66,6 +66,8 @@ const MASTER_DATA: MasterData = {
   recruiting_post_types: [],
 };
 
+const SEARCH_QUERY_KEY = "search_query";
+
 interface FilterProps {
   filterType: "profileFilter" | "recruitmentPostFilter";
 }
@@ -91,11 +93,21 @@ export default function Filter({ filterType }: FilterProps) {
     { id: "bookmark", name: "북마크만" },
   ];
 
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const handleInputChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+    searchParams.set(SEARCH_QUERY_KEY, e.target.value);
+    setSearchParams(searchParams);
+  };
+
   return (
     <div className="flex flex-col border-2 border-neutral-600 rounded-xl max-w-sm p-2">
       <div className="flex items-center justify-between space-x-1.5 px-1">
         <BsFillFunnelFill size={24} />
-        <input className="rounded-full bg-bg-on-dark text-text-on-dark px-3 py-0.5 focus:outline-none flex-1" />
+        <input
+          onChange={handleInputChange}
+          className="rounded-full bg-bg-on-dark text-text-on-dark px-3 py-0.5 focus:outline-none flex-1"
+        />
       </div>
       <div className="flex flex-col space-y-2">
         <FilterSection queryKey="sort_by" title={"순서"} data={orders} mode="single" />

--- a/src/components/Filter.tsx
+++ b/src/components/Filter.tsx
@@ -3,6 +3,7 @@ import Badge from "@/components/Badge";
 import Text from "@/components/text/Text";
 import { useSearchParams } from "react-router";
 import { cn } from "@/libs/utils";
+import { useMultiSelectQuery } from "@/hooks/useMultiSelectQuery";
 
 //마스터 데이터 실제론 api로 받기
 const MASTER_DATA: MasterData = {
@@ -122,49 +123,25 @@ interface FilterSectionProps {
   queryKey: string;
 }
 function FilterSection({ title, data, queryKey }: FilterSectionProps) {
-  const [searchParams, setSearchParams] = useSearchParams();
-
-  /** 특정 queryKey에 대해 값(id)을 토글하는 함수 */
-  const toggleQueryParam = (key: string, value: string) => {
-    const currentValues = searchParams.get(key)?.split(",").filter(Boolean) ?? [];
-
-    let updatedValues: string[];
-    if (currentValues.includes(value)) {
-      updatedValues = currentValues.filter((v) => v !== value); // 제거
-    } else {
-      updatedValues = [...currentValues, value]; // 추가
-    }
-
-    if (updatedValues.length > 0) {
-      searchParams.set(key, updatedValues.join(","));
-    } else {
-      searchParams.delete(key);
-    }
-
-    setSearchParams(searchParams);
-  };
-
+  const { isSelected, toggleValue } = useMultiSelectQuery(queryKey);
   return (
     <section className="flex flex-col items-start space-y-1">
       <Text variant="mainText">{title}</Text>
       <div className="flex flex-wrap items-start justify-start gap-0.5">
         {data.map((item) => {
-          const selectedValues = searchParams.get(queryKey)?.split(",").filter(Boolean) ?? [];
-          const isSelected = selectedValues.includes(item.id);
-
           return (
             <Badge
-              color={isSelected ? "primary" : "primarySoft"}
+              color={isSelected(item.id) ? "primary" : "primarySoft"}
               size="sm"
               textVariant="label"
               key={item.id}
               onClick={(e) => {
                 e.preventDefault();
-                toggleQueryParam(queryKey, item.id);
+                toggleValue(item.id);
               }}
               className={cn(
                 "cursor-pointer ",
-                isSelected ? " hover:bg-primary-soft" : "hover:bg-primary"
+                isSelected(item.id) ? " hover:bg-primary-soft" : "hover:bg-primary"
               )}
             >
               {item.name}

--- a/src/components/Filter.tsx
+++ b/src/components/Filter.tsx
@@ -3,7 +3,7 @@ import Badge from "@/components/Badge";
 import Text from "@/components/text/Text";
 import { useSearchParams } from "react-router";
 import { cn } from "@/libs/utils";
-import { useMultiSelectQuery } from "@/hooks/useMultiSelectQuery";
+import { useSelectQuery } from "@/hooks/useSelectQuery";
 
 //마스터 데이터 실제론 api로 받기
 const MASTER_DATA: MasterData = {
@@ -98,8 +98,8 @@ export default function Filter({ filterType }: FilterProps) {
         <input className="rounded-full bg-bg-on-dark text-text-on-dark px-3 py-0.5 focus:outline-none flex-1" />
       </div>
       <div className="flex flex-col space-y-2">
-        <FilterSection queryKey="sort_by" title={"순서"} data={orders} />
-        <FilterSection queryKey="bookmark" title={"북마크"} data={bookmarks} />
+        <FilterSection queryKey="sort_by" title={"순서"} data={orders} mode="single" />
+        <FilterSection queryKey="bookmark" title={"북마크"} data={bookmarks} mode="single" />
         <FilterSection queryKey="region_ids" title={"지역"} data={regions} />
         <FilterSection queryKey="genre_ids" title={"선호 장르"} data={genres} />
         <FilterSection queryKey="positions_id" title={"포지션"} data={positions} />
@@ -121,9 +121,11 @@ interface FilterSectionProps {
     name: string;
   }[];
   queryKey: string;
+  mode?: "multi" | "single";
 }
-function FilterSection({ title, data, queryKey }: FilterSectionProps) {
-  const { isSelected, toggleValue } = useMultiSelectQuery(queryKey);
+function FilterSection({ title, data, queryKey, mode = "multi" }: FilterSectionProps) {
+  const { isSelected, toggleValue } = useSelectQuery(queryKey, mode);
+
   return (
     <section className="flex flex-col items-start space-y-1">
       <Text variant="mainText">{title}</Text>

--- a/src/components/Filter.tsx
+++ b/src/components/Filter.tsx
@@ -107,14 +107,14 @@ export default function Filter({ filterType }: FilterProps) {
   return (
     <div className="flex flex-col border-2 border-neutral-600 rounded-xl max-w-sm p-2">
       <div className="flex items-center justify-between space-x-1.5 px-1">
-        <BsFillFunnelFill size={24} />
+        <BsFillFunnelFill size={24} className="cursor-pointer sm:cursor-default flex-shrink-0" />
         <input
           onChange={handleInputChange}
-          className="rounded-full bg-bg-on-dark text-text-on-dark px-3 py-0.5 focus:outline-none flex-1"
+          className="rounded-full bg-bg-on-dark text-text-on-dark px-3 py-0.5 focus:outline-none flex-1 min-w-0"
         />
         <BsArrowCounterclockwise
           size={24}
-          className="cursor-pointer"
+          className="cursor-pointer flex-shrink-0"
           onClick={handleInitializeClick}
         />
       </div>

--- a/src/components/Filter.tsx
+++ b/src/components/Filter.tsx
@@ -1,5 +1,85 @@
+import { BsFillFunnelFill } from "react-icons/bs";
+
+//마스터 데이터 실제론 api로 받기
+const MASTER_DATA: MasterData = {
+  regions: [
+    { id: "1", name: "서울 서부" },
+    { id: "2", name: "서울 동부" },
+    { id: "3", name: "서울 남부" },
+    { id: "4", name: "서울 북부" },
+    { id: "5", name: "인천" },
+    { id: "6", name: "부산" },
+    { id: "7", name: "대구" },
+    { id: "8", name: "광주" },
+    { id: "9", name: "대전" },
+    { id: "10", name: "울산" },
+    { id: "11", name: "제주" },
+    { id: "12", name: "경기" },
+    { id: "13", name: "강원" },
+    { id: "14", name: "충북" },
+    { id: "15", name: "충남" },
+    { id: "16", name: "경북" },
+    { id: "17", name: "경남" },
+    { id: "18", name: "전북" },
+    { id: "19", name: "전남" },
+  ],
+  positions: [
+    { id: "p1", name: "보컬" },
+    { id: "p2", name: "일렉 기타" },
+    { id: "p3", name: "어쿠스틱 기타" },
+    { id: "p4", name: "베이스" },
+    { id: "p5", name: "드럼" },
+    { id: "p6", name: "키보드" },
+    { id: "p7", name: "그 외" },
+  ],
+  genres: [
+    { id: "g1", name: "인디락" },
+    { id: "g2", name: "K-pop" },
+    { id: "g3", name: "J-pop" },
+    { id: "g4", name: "메탈" },
+    { id: "g5", name: "하드락" },
+    { id: "g6", name: "재즈" },
+    { id: "g7", name: "그 외" },
+  ],
+  experience_levels: [
+    { id: "e1", name: "취미 1년 이하" },
+    { id: "e2", name: "취미 3년 이하" },
+    { id: "e3", name: "취미 5년 이하" },
+    { id: "e4", name: "취미 5년 이상" },
+    { id: "e5", name: "전공" },
+    { id: "e6", name: "프로" },
+  ],
+  orientations: [
+    { id: "o1", name: "취미" },
+    { id: "o2", name: "프로" },
+    { id: "o3", name: "프로 지향" },
+  ],
+  recruitment_types: [
+    { id: "r1", name: "고정 밴드" },
+    { id: "r2", name: "프로젝트 밴드" },
+  ],
+  recruiting_post_types: [],
+};
+
 interface FilterProps {}
 
 export default function Filter({}: FilterProps) {
-  return <div>Filter</div>;
+  //마스터 데이터 실제론 api로 받기
+  const {
+    regions,
+    positions,
+    genres,
+    experience_levels: experienceLevel,
+    orientations,
+    recruitment_types: recruitmentTypes,
+  } = MASTER_DATA;
+
+  return (
+    <div className="flex flex-col border-2 border-neutral-600 rounded-xl max-w-sm p-2">
+      <div className="flex items-center justify-between space-x-1.5 px-1">
+        <BsFillFunnelFill size={24} />
+        <input className="rounded-full bg-bg-on-dark text-text-on-dark px-3 py-0.5 focus:outline-none flex-1" />
+      </div>
+    </div>
+  );
 }

--- a/src/components/Filter.tsx
+++ b/src/components/Filter.tsx
@@ -68,6 +68,7 @@ const MASTER_DATA: MasterData = {
   recruiting_post_types: [],
 };
 
+const NICKNAME_QUERY_KEY = "nickname";
 const SEARCH_QUERY_KEY = "search_query";
 const MOBILE_SIZE_PX = 640;
 
@@ -105,7 +106,8 @@ export default function Filter({
   const [searchParams, setSearchParams] = useSearchParams();
 
   const handleInputChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
-    searchParams.set(SEARCH_QUERY_KEY, e.target.value);
+    const queryKey = filterType === "profileFilter" ? NICKNAME_QUERY_KEY : SEARCH_QUERY_KEY;
+    searchParams.set(queryKey, e.target.value);
     setSearchParams(searchParams);
   };
 

--- a/src/components/Filter.tsx
+++ b/src/components/Filter.tsx
@@ -196,7 +196,10 @@ function FilterSection({ title, data, queryKey, mode = "multi" }: FilterSectionP
                 e.preventDefault();
                 toggleValue(item.id);
               }}
-              className={cn("cursor-pointer ", isSelected(item.id) ? "" : "hover:bg-primary")}
+              className={cn(
+                "cursor-pointer ",
+                isSelected(item.id) ? "text-text-on-dark" : "hover:bg-primary"
+              )}
             >
               {item.name}
             </Badge>

--- a/src/hooks/useMultiSelectQuery.ts
+++ b/src/hooks/useMultiSelectQuery.ts
@@ -1,0 +1,31 @@
+import { useSearchParams } from "react-router-dom";
+
+export function useMultiSelectQuery(key: string) {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const selectedValues = searchParams.get(key)?.split(",").filter(Boolean) ?? [];
+
+  /** 선택된 값에 포함되는지 여부 */
+  const isSelected = (value: string) => selectedValues.includes(value);
+
+  /** 값 토글 (추가/제거) */
+  const toggleValue = (value: string) => {
+    let updated: string[];
+
+    if (isSelected(value)) {
+      updated = selectedValues.filter((v) => v !== value);
+    } else {
+      updated = [...selectedValues, value];
+    }
+
+    if (updated.length > 0) {
+      searchParams.set(key, updated.join(","));
+    } else {
+      searchParams.delete(key);
+    }
+
+    setSearchParams(searchParams);
+  };
+
+  return { selectedValues, isSelected, toggleValue };
+}

--- a/src/hooks/useSelectQuery.ts
+++ b/src/hooks/useSelectQuery.ts
@@ -3,7 +3,7 @@ import { useSearchParams } from "react-router-dom";
 
 type Mode = "multi" | "single";
 
-export function useSelectQuery(key: string, mode: Mode = "multi") {
+function useSelectQuery(key: string, mode: Mode = "multi") {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const selectedValues = searchParams.get(key)?.split(",").filter(Boolean) ?? [];
@@ -40,3 +40,5 @@ export function useSelectQuery(key: string, mode: Mode = "multi") {
 
   return { selectedValues, isSelected, toggleValue };
 }
+
+export default useSelectQuery;

--- a/src/hooks/useSelectQuery.ts
+++ b/src/hooks/useSelectQuery.ts
@@ -1,21 +1,32 @@
+// hooks/useSelectQuery.ts
 import { useSearchParams } from "react-router-dom";
 
-export function useMultiSelectQuery(key: string) {
+type Mode = "multi" | "single";
+
+export function useSelectQuery(key: string, mode: Mode = "multi") {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const selectedValues = searchParams.get(key)?.split(",").filter(Boolean) ?? [];
 
-  /** 선택된 값에 포함되는지 여부 */
   const isSelected = (value: string) => selectedValues.includes(value);
 
-  /** 값 토글 (추가/제거) */
   const toggleValue = (value: string) => {
     let updated: string[];
 
-    if (isSelected(value)) {
-      updated = selectedValues.filter((v) => v !== value);
+    if (mode === "single") {
+      // 단일 선택 모드
+      if (isSelected(value)) {
+        updated = [];
+      } else {
+        updated = [value];
+      }
     } else {
-      updated = [...selectedValues, value];
+      // 다중 선택 모드
+      if (isSelected(value)) {
+        updated = selectedValues.filter((v) => v !== value);
+      } else {
+        updated = [...selectedValues, value];
+      }
     }
 
     if (updated.length > 0) {

--- a/src/hooks/useWindowWidth.ts
+++ b/src/hooks/useWindowWidth.ts
@@ -1,0 +1,21 @@
+import { useState, useEffect } from "react";
+
+function useWindowWidth(): number {
+  const [windowWidth, setWindowWidth] = useState<number>(window.innerWidth);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setWindowWidth(window.innerWidth);
+    };
+
+    window.addEventListener("resize", handleResize);
+
+    handleResize();
+
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return windowWidth;
+}
+
+export default useWindowWidth;

--- a/src/pages/recruitment-post/RecruitmentList.tsx
+++ b/src/pages/recruitment-post/RecruitmentList.tsx
@@ -2,8 +2,9 @@ import Filter from "@/components/Filter";
 
 export default function RecruitmentList() {
   return (
-    <div>
-      <Filter />
+    <div className="p-4 gap-2 flex flex-col">
+      <Filter filterType="recruitmentPostFilter" />
+      <Filter filterType="profileFilter" />
       RecruitmentList
     </div>
   );

--- a/src/pages/recruitment-post/RecruitmentList.tsx
+++ b/src/pages/recruitment-post/RecruitmentList.tsx
@@ -4,7 +4,6 @@ export default function RecruitmentList() {
   return (
     <div className="p-4 gap-2 flex flex-col">
       <Filter filterType="recruitmentPostFilter" />
-      <Filter filterType="profileFilter" />
       RecruitmentList
     </div>
   );

--- a/src/pages/recruitment-post/RecruitmentList.tsx
+++ b/src/pages/recruitment-post/RecruitmentList.tsx
@@ -1,3 +1,10 @@
+import Filter from "@/components/Filter";
+
 export default function RecruitmentList() {
-  return <div>RecruitmentList</div>;
+  return (
+    <div>
+      <Filter />
+      RecruitmentList
+    </div>
+  );
 }


### PR DESCRIPTION
## 📌 개요

구인글 리스트, 프로필 리스트 필터 제작

## ✅ 작업 내용

- 각 뱃지 클릭 시 혹은 input에 내용 입력 시 url의 query parameter 변경
- query parameter 값은 react-router-dom의 useSearchParams 훅 사용
- 순서와 북마크 항목은 단일 선택 나머지는 복수 선택
- 모바일은 접었다 폈다 할 수 있다.
- 모바일의 기준은 default로 640px이나 prop으로 조절 가능하다.
- useWindowWidth 훅
- useSelectQuery 훅

## 🔍 관련 이슈

Closes #96

## 📸 스크린샷 (선택)
### 데스크탑 예시
+ 위 url의 쿼리 파라미터가 바뀌는 것 주목
<img width="2541" height="763" alt="Screenshot 2025-08-12 at 1 47 54 PM" src="https://github.com/user-attachments/assets/63159872-c03b-4471-b53f-8b3d5a109345" />

### 모바일 접음
<img width="392" height="841" alt="Screenshot 2025-08-12 at 1 49 09 PM" src="https://github.com/user-attachments/assets/57fa8733-2efc-4c78-a09e-2269643222b3" />

### 모바일 폄
<img width="392" height="843" alt="Screenshot 2025-08-12 at 1 50 43 PM" src="https://github.com/user-attachments/assets/8ea3e62a-2929-4863-a8dd-77d442f961e7" />