### PR TITLE
 #108 프로필 리스트 제작, 필터 적용 및 무한 스크롤 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ function App() {
           <Route index element={<RecruitmentList />} />
         </Route>
 
-        <Route path="profile">
+        <Route path="/profile">
           <Route index element={<ProfileList />} />
         </Route>
       </Route>

--- a/src/Mocks/mockProfiles.ts
+++ b/src/Mocks/mockProfiles.ts
@@ -1,0 +1,311 @@
+// src/mocks/mockProfiles.ts
+import type { UserProfile } from "@/types/api-res-profile";
+
+export const mockProfiles: UserProfile[] = [
+  {
+    user_id: "u1",
+    nickname: "김하늘",
+    image_url: "",
+    is_bookmarked: false,
+    regions: [{ id: "1", name: "서울 서부" }],
+    positions: [
+      {
+        position: { id: "p1", name: "보컬" },
+        experience_level: { id: "e1", name: "취미 1년 이하" },
+      },
+    ],
+    genres: [
+      { id: "g1", name: "인디락" },
+      { id: "g2", name: "K-pop" },
+    ],
+    email: "haneul@example.com",
+  },
+  {
+    user_id: "u2",
+    nickname: "이도현",
+    image_url: "",
+    is_bookmarked: true,
+    regions: [{ id: "2", name: "서울 동부" }],
+    positions: [
+      {
+        position: { id: "p2", name: "일렉 기타" },
+        experience_level: { id: "e2", name: "취미 3년 이하" },
+      },
+    ],
+    genres: [{ id: "g3", name: "J-pop" }],
+    email: "dohyun@example.com",
+  },
+  {
+    user_id: "u3",
+    nickname: "박서연",
+    image_url: "",
+    is_bookmarked: false,
+    regions: [{ id: "3", name: "서울 남부" }],
+    positions: [
+      {
+        position: { id: "p3", name: "어쿠스틱 기타" },
+        experience_level: { id: "e3", name: "취미 5년 이하" },
+      },
+    ],
+    genres: [{ id: "g4", name: "메탈" }],
+    email: "seoyeon@example.com",
+  },
+  {
+    user_id: "u4",
+    nickname: "정민우",
+    image_url: "",
+    is_bookmarked: true,
+    regions: [{ id: "4", name: "서울 북부" }],
+    positions: [
+      {
+        position: { id: "p4", name: "베이스" },
+        experience_level: { id: "e4", name: "취미 5년 이상" },
+      },
+    ],
+    genres: [{ id: "g5", name: "하드락" }],
+    email: "minwoo@example.com",
+  },
+  {
+    user_id: "u5",
+    nickname: "최가영",
+    image_url: "",
+    is_bookmarked: false,
+    regions: [{ id: "5", name: "부산" }],
+    positions: [
+      {
+        position: { id: "p5", name: "드럼" },
+        experience_level: { id: "e5", name: "전공" },
+      },
+    ],
+    genres: [{ id: "g6", name: "재즈" }],
+    email: "gayoung@example.com",
+  },
+  {
+    user_id: "u6",
+    nickname: "한지훈",
+    image_url: "",
+    is_bookmarked: true,
+    regions: [{ id: "6", name: "인천" }],
+    positions: [
+      {
+        position: { id: "p6", name: "키보드" },
+        experience_level: { id: "e2", name: "취미 3년 이하" },
+      },
+    ],
+    genres: [
+      { id: "g2", name: "K-pop" },
+      { id: "g7", name: "그 외" },
+    ],
+    email: "jihoon@example.com",
+  },
+  {
+    user_id: "u7",
+    nickname: "서지우",
+    image_url: "",
+    is_bookmarked: false,
+    regions: [{ id: "7", name: "대구" }],
+    positions: [
+      {
+        position: { id: "p2", name: "일렉 기타" },
+        experience_level: { id: "e1", name: "취미 1년 이하" },
+      },
+    ],
+    genres: [{ id: "g1", name: "인디락" }],
+    email: "jiwoo@example.com",
+  },
+  {
+    user_id: "u8",
+    nickname: "오유진",
+    image_url: "",
+    is_bookmarked: true,
+    regions: [{ id: "8", name: "광주" }],
+    positions: [
+      {
+        position: { id: "p3", name: "드럼" },
+        experience_level: { id: "e3", name: "취미 5년 이하" },
+      },
+    ],
+    genres: [{ id: "g3", name: "J-pop" }],
+    email: "yujin@example.com",
+  },
+  {
+    user_id: "u9",
+    nickname: "윤태호",
+    image_url: "",
+    is_bookmarked: false,
+    regions: [{ id: "9", name: "대전" }],
+    positions: [
+      {
+        position: { id: "p4", name: "베이스" },
+        experience_level: { id: "e2", name: "취미 3년 이하" },
+      },
+    ],
+    genres: [{ id: "g5", name: "하드락" }],
+    email: "taeho@example.com",
+  },
+  {
+    user_id: "u10",
+    nickname: "장하린",
+    image_url: "",
+    is_bookmarked: true,
+    regions: [{ id: "10", name: "울산" }],
+    positions: [
+      {
+        position: { id: "p6", name: "키보드" },
+        experience_level: { id: "e4", name: "취미 5년 이상" },
+      },
+    ],
+    genres: [{ id: "g6", name: "재즈" }],
+    email: "harin@example.com",
+  },
+  {
+    user_id: "u11",
+    nickname: "강현우",
+    image_url: "",
+    is_bookmarked: false,
+    regions: [{ id: "11", name: "제주" }],
+    positions: [
+      {
+        position: { id: "p1", name: "보컬" },
+        experience_level: { id: "e5", name: "전공" },
+      },
+    ],
+    genres: [{ id: "g2", name: "K-pop" }],
+    email: "hyunwoo@example.com",
+  },
+  {
+    user_id: "u12",
+    nickname: "백소연",
+    image_url: "",
+    is_bookmarked: true,
+    regions: [{ id: "1", name: "서울 서부" }],
+    positions: [
+      {
+        position: { id: "p2", name: "일렉 기타" },
+        experience_level: { id: "e1", name: "취미 1년 이하" },
+      },
+    ],
+    genres: [{ id: "g4", name: "메탈" }],
+    email: "soyeon@example.com",
+  },
+  {
+    user_id: "u13",
+    nickname: "임재혁",
+    image_url: "",
+    is_bookmarked: false,
+    regions: [{ id: "3", name: "서울 남부" }],
+    positions: [
+      {
+        position: { id: "p3", name: "어쿠스틱 기타" },
+        experience_level: { id: "e2", name: "취미 3년 이하" },
+      },
+    ],
+    genres: [{ id: "g5", name: "하드락" }],
+    email: "jaehyuk@example.com",
+  },
+  {
+    user_id: "u14",
+    nickname: "홍지민",
+    image_url: "",
+    is_bookmarked: true,
+    regions: [{ id: "5", name: "부산" }],
+    positions: [
+      {
+        position: { id: "p7", name: "그 외" },
+        experience_level: { id: "e3", name: "취미 5년 이하" },
+      },
+    ],
+    genres: [{ id: "g1", name: "인디락" }],
+    email: "jimin@example.com",
+  },
+  {
+    user_id: "u15",
+    nickname: "노유나",
+    image_url: "",
+    is_bookmarked: false,
+    regions: [{ id: "7", name: "대구" }],
+    positions: [
+      {
+        position: { id: "p5", name: "드럼" },
+        experience_level: { id: "e2", name: "취미 3년 이하" },
+      },
+    ],
+    genres: [{ id: "g3", name: "J-pop" }],
+    email: "yuna@example.com",
+  },
+  {
+    user_id: "u16",
+    nickname: "하도윤",
+    image_url: "",
+    is_bookmarked: true,
+    regions: [{ id: "8", name: "광주" }],
+    positions: [
+      {
+        position: { id: "p1", name: "보컬" },
+        experience_level: { id: "e6", name: "프로" },
+      },
+    ],
+    genres: [{ id: "g6", name: "재즈" }],
+    email: "doyoon@example.com",
+  },
+  {
+    user_id: "u17",
+    nickname: "문예린",
+    image_url: "",
+    is_bookmarked: false,
+    regions: [{ id: "2", name: "서울 동부" }],
+    positions: [
+      {
+        position: { id: "p7", name: "그 외" },
+        experience_level: { id: "e5", name: "전공" },
+      },
+    ],
+    genres: [{ id: "g2", name: "K-pop" }],
+    email: "yerin@example.com",
+  },
+  {
+    user_id: "u18",
+    nickname: "배시후",
+    image_url: "",
+    is_bookmarked: true,
+    regions: [{ id: "6", name: "인천" }],
+    positions: [
+      {
+        position: { id: "p3", name: "어쿠스틱 기타" },
+        experience_level: { id: "e1", name: "취미 1년 이하" },
+      },
+    ],
+    genres: [{ id: "g4", name: "메탈" }],
+    email: "sihoo@example.com",
+  },
+  {
+    user_id: "u19",
+    nickname: "조아인",
+    image_url: "",
+    is_bookmarked: false,
+    regions: [{ id: "9", name: "대전" }],
+    positions: [
+      {
+        position: { id: "p4", name: "베이스" },
+        experience_level: { id: "e2", name: "취미 3년 이하" },
+      },
+    ],
+    genres: [{ id: "g5", name: "하드락" }],
+    email: "ain@example.com",
+  },
+  {
+    user_id: "u20",
+    nickname: "양채원",
+    image_url: "",
+    is_bookmarked: true,
+    regions: [{ id: "10", name: "울산" }],
+    positions: [
+      {
+        position: { id: "p5", name: "드럼" },
+        experience_level: { id: "e3", name: "취미 5년 이하" },
+      },
+    ],
+    genres: [{ id: "g6", name: "재즈" }],
+    email: "chaewon@example.com",
+  },
+];

--- a/src/components/Filter.tsx
+++ b/src/components/Filter.tsx
@@ -105,6 +105,7 @@ export default function Filter({
   ];
 
   const [searchParams, setSearchParams] = useSearchParams();
+  const isProfile = filterType === "profileFilter"; // ✅ 추가
 
   const handleInputChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
     const queryKey = filterType === "profileFilter" ? NICKNAME_QUERY_KEY : SEARCH_QUERY_KEY;
@@ -156,7 +157,10 @@ export default function Filter({
         />
       </div>
       <div className={cn("flex flex-col space-y-2", isVisible ? "visible" : "hidden")}>
-        <FilterSection queryKey="sort_by" title={"순서"} data={orders} mode="single" />
+        {/* 프로필 카드일 경우 순서, 지향은 숨김 */}
+        {!isProfile && (
+          <FilterSection queryKey="sort_by" title="순서" data={orders} mode="single" />
+        )}
         <FilterSection queryKey="bookmark" title={"북마크"} data={bookmarks} mode="single" />
         <FilterSection queryKey="region_ids" title={"지역"} data={regions} />
         <FilterSection queryKey="genre_ids" title={"선호 장르"} data={genres} />
@@ -166,7 +170,9 @@ export default function Filter({
           title={filterType === "recruitmentPostFilter" ? "요구 경력" : "경력"}
           data={experienceLevels}
         />
-        <FilterSection queryKey="orientation_ids" title={"지향"} data={orientations} />
+        {!isProfile && (
+          <FilterSection queryKey="orientation_ids" title="지향" data={orientations} />
+        )}
       </div>
     </div>
   );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -6,7 +6,7 @@ import type { JSX } from "react";
 
 export default function Footer(): JSX.Element {
   return (
-    <footer className="bg-bg-primary text-sm absolute bottom-0 w-full">
+    <footer className="bg-bg-primary text-sm w-full border-t mt-5">
       <div className="grid gap-8 md:grid-cols-2 px-10 py-6 w-full md:px-20">
         <div className="flex justify-center md:justify-normal gap-20 ">
           <AiOutlineFacebook size={28} />

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -1,10 +1,10 @@
-import H2 from "@/components/text/H2";
 import Text from "@/components/text/Text";
 import Badge from "@/components/Badge";
 import BookmarkBtn from "@/components/BookmarkBtn";
 import defaultImage from "@/assets/images/user-default-image.png";
 import type { UserProfile } from "@/types/api-res-profile";
 import { cn } from "@/libs/utils";
+import H3 from "./text/H3";
 
 interface ProfileCardProps {
   profile: UserProfile;
@@ -27,9 +27,9 @@ export default function ProfileCard({ profile }: ProfileCardProps) {
   return (
     <div
       className={cn(
-        "relative w-75 rounded-xl bg-bg-secondary px-4 pt-2 pb-5",
+        "relative w-75 rounded-xl px-4 pt-2 pb-5",
         "shadow-sm border border-gray-300",
-        "hover:shadow-lg hover:shadow-primary-thick",
+        "hover:shadow-lg hover:shadow-primary-soft",
         "transition-all duration-300 ease-in-out"
       )}
     >
@@ -45,7 +45,7 @@ export default function ProfileCard({ profile }: ProfileCardProps) {
 
         {/* 중앙: 닉네임 */}
         <div className="flex-1 text-center">
-          <H2 className="text-base">{nickname}</H2>
+          <H3 className="text-base">{nickname}</H3>
         </div>
 
         {/* 우측: 북마크 버튼 */}
@@ -57,19 +57,19 @@ export default function ProfileCard({ profile }: ProfileCardProps) {
       <div className="flex items-center gap-4 mt-4 text-left">
         {/* 포지션 */}
         <div className="flex items-center gap-1">
-          <Text variant="label">포지션</Text>
+          <Text variant="label">포지션:</Text>
           <Badge label={positionName} color="primarySoft" size="sm" />
         </div>
         {/* 경력 */}
         <div className="flex items-center gap-1">
-          <Text variant="label">경력</Text>
+          <Text variant="label">경력:</Text>
           <Text variant="label">{experienceName}</Text>
         </div>
       </div>
 
       {/* 선호 장르 */}
       <div className="mt-3 text-left">
-        <Text variant="label">선호 장르</Text>
+        <Text variant="label">선호 장르:</Text>
         {genres.map((genre) => (
           <Badge key={genre.id} label={genre.name} color="primarySoft" size="sm" />
         ))}

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -2,7 +2,7 @@ import H2 from "@/components/text/H2";
 import Text from "@/components/text/Text";
 import Badge from "@/components/Badge";
 import BookmarkBtn from "@/components/BookmarkBtn";
-import defalutImage from "@/assets/images/user-default-image.png";
+import defaultImage from "@/assets/images/user-default-image.png";
 import type { UserProfile } from "@/types/api-res-profile";
 import { cn } from "@/libs/utils";
 
@@ -20,14 +20,14 @@ export default function ProfileCard({ profile }: ProfileCardProps) {
     genres,
     email,
   } = profile;
-  const firstPosition = positions[0];
+  const firstPosition = positions?.[0];
   const positionName = firstPosition?.position.name ?? "포지션 없음";
   const experienceName = firstPosition?.experience_level.name ?? "미정";
 
   return (
     <div
       className={cn(
-        "relative w-80 rounded-xl bg-bg-secondary px-4 pt-2 pb-5",
+        "relative w-75 rounded-xl bg-bg-secondary px-4 pt-2 pb-5",
         "shadow-sm border border-gray-300",
         "hover:shadow-lg hover:shadow-primary-thick",
         "transition-all duration-300 ease-in-out"
@@ -37,7 +37,7 @@ export default function ProfileCard({ profile }: ProfileCardProps) {
         {/* 좌측: 프로필 이미지 */}
         <div className="w-12 h-12 rounded-full overflow-hidden border border-gray-300 shrink-0">
           <img
-            src={imageUrl || defalutImage}
+            src={imageUrl || defaultImage}
             alt={`${nickname}님의 프로필 사진`}
             className="w-full h-full object-cover"
           />
@@ -58,7 +58,7 @@ export default function ProfileCard({ profile }: ProfileCardProps) {
         {/* 포지션 */}
         <div className="flex items-center gap-1">
           <Text variant="label">포지션</Text>
-          <Badge label={positionName} color="primary" size="sm" />
+          <Badge label={positionName} color="primarySoft" size="sm" />
         </div>
         {/* 경력 */}
         <div className="flex items-center gap-1">
@@ -71,7 +71,7 @@ export default function ProfileCard({ profile }: ProfileCardProps) {
       <div className="mt-3 text-left">
         <Text variant="label">선호 장르</Text>
         {genres.map((genre) => (
-          <Badge key={genre.id} label={genre.name} color="primary" size="sm" />
+          <Badge key={genre.id} label={genre.name} color="primarySoft" size="sm" />
         ))}
       </div>
 

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -29,7 +29,7 @@ const Header: FC = () => {
 
   return (
     <header
-      className={`relative flex justify-between items-center w-full h-[52px] sm:h-[80px] px-4 sm:px-6 sm:py-0 ${isBurgerOpen ? "shadow-lg" : ""} sm:shadow-none`}
+      className={`relative z-40 flex justify-between items-center w-full h-[52px] sm:h-[80px] px-4 sm:px-6 sm:py-0 ${isBurgerOpen ? "shadow-lg" : ""} sm:shadow-none`}
     >
       {/* 메인 로고 */}
       <Link to="/">
@@ -38,7 +38,7 @@ const Header: FC = () => {
 
       {/* 데스크톱 네비게이션 링크 (PC에서만 보임) */}
       <div className="items-center justify-around hidden gap-16 sm:flex">
-        <NavigationLink title="Profile List" to="#" />
+        <NavigationLink title="Profile List" to="/profile" />
         <NavigationLink title="Find People" to="#" />
       </div>
 
@@ -90,7 +90,7 @@ const Header: FC = () => {
       {isBurgerOpen && (
         <div className="absolute flex flex-col w-[40%] bg-white right-0 top-full text-left p-5 sm:hidden rounded-bl-xl gap-2 shadow-xl">
           <div className="flex flex-col gap-4 my-4">
-            <NavigationLink to="#" title="Profile List" onClick={toggleBurger} />
+            <NavigationLink to="/profile" title="Profile List" onClick={toggleBurger} />
             <NavigationLink to="#" title="People List" onClick={toggleBurger} />
           </div>
           {isLogin ? (

--- a/src/components/loading/InlineDots.tsx
+++ b/src/components/loading/InlineDots.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/libs/utils";
+
+export default function InlineDots() {
+  return (
+    <div
+      className={cn("col-span-full", "flex items-center justify-center gap-2 py-6")}
+      role="status"
+      aria-live="polite"
+    >
+      <span className={cn("animate-pulse")}>•</span>
+      <span className={cn("animate-pulse", "[animation-delay:100ms]")}>•</span>
+      <span className={cn("animate-pulse", "[animation-delay:200ms]")}>•</span>
+    </div>
+  );
+}

--- a/src/hooks/useInfinite.ts
+++ b/src/hooks/useInfinite.ts
@@ -1,0 +1,37 @@
+// src/hooks/useInfinite.ts
+import {
+  useInfiniteQuery,
+  type UseInfiniteQueryResult,
+  type InfiniteData,
+} from "@tanstack/react-query";
+
+/** 각 페이지 표준 형태: 아이템 배열 + 다음 커서 */
+export type InfinitePage<T> = {
+  items: T[];
+  next_cursor?: string | null | "";
+};
+
+/** 범용 무한스크롤 훅
+ * - queryKey: React Query 키 (필터/정렬 등 포함)
+ * - fetchPage: 페이지 로더(pageParam를 받아 다음 페이지를 반환)
+ */
+export function useInfinite<T>({
+  queryKey,
+  fetchPage,
+}: {
+  queryKey: unknown[];
+  fetchPage: (args: { pageParam?: string }) => Promise<InfinitePage<T>>;
+}): UseInfiniteQueryResult<InfiniteData<InfinitePage<T>, Error>> {
+  return useInfiniteQuery({
+    queryKey,
+    queryFn: ({ pageParam }) => fetchPage({ pageParam }),
+    initialPageParam: "0",
+    getNextPageParam: (lastPage) =>
+      lastPage.next_cursor ? String(lastPage.next_cursor) : undefined,
+  });
+}
+
+/** 편의 함수: pages 배열을 평탄화하여 모든 items를 반환 */
+export function flattenInfiniteItems<T>(data?: InfiniteData<InfinitePage<T>>) {
+  return data?.pages.flatMap((p) => p.items) ?? [];
+}

--- a/src/libs/buildProfilesquery.ts
+++ b/src/libs/buildProfilesquery.ts
@@ -1,0 +1,60 @@
+export type ProfilesQuery = {
+  limit?: string; // 한 번에 가져올 데이터 개수
+  cursor?: string; // 페이지네이션 커서
+  nickname?: string; // 필터: 닉네임 검색
+  region_ids?: string; // 필터: 지역 ID 목록 (쉼표 구분)
+  position_ids?: string; // 필터: 포지션 ID 목록 (쉼표 구분)
+  genre_ids?: string; // 필터: 장르 ID 목록 (쉼표 구분)
+  experience_level_ids?: string; // 필터: 경력 레벨 ID 목록 (쉼표 구분)
+  sort_by?: "latest" | "bookmarks" | "views"; // 정렬 기준
+  order_by?: "asc" | "desc"; // 정렬 순서
+  bookmark?: "bookmark" | "all"; // 북마크 필터 (북마크만 / 전체)
+};
+
+// URLSearchParams 객체에서 쿼리스트링 값을 읽어와 ProfilesQuery 객체를 생성하는 함수
+export function buildProfilesQueryFromSearchParams(sp: URLSearchParams): ProfilesQuery {
+  const q: ProfilesQuery = {}; // 반환할 쿼리 객체
+
+  // 닉네임 필터 적용
+  const nickname = sp.get("nickname");
+  if (nickname) q.nickname = nickname;
+
+  // 지역 필터 적용
+  const region = sp.get("region_ids");
+  if (region) q.region_ids = region;
+
+  // 포지션 필터 적용
+  const position = sp.get("position_ids") ?? sp.get("positions_id");
+  if (position) q.position_ids = position;
+
+  // 장르 필터 적용
+  const genre = sp.get("genre_ids");
+  if (genre) q.genre_ids = genre;
+
+  // 경력 레벨 필터 적용
+  const exp = sp.get("experience_level_ids");
+  if (exp) q.experience_level_ids = exp;
+
+  // 정렬 기준 적용 (latest, bookmarks, views 중 하나만 허용)
+  const sort = sp.get("sort_by");
+  if (sort && ["latest", "bookmarks", "views"].includes(sort)) q.sort_by = sort as any;
+
+  // 정렬 순서 적용 (asc 또는 desc만 허용)
+  const order = sp.get("order_by");
+  if (order && ["asc", "desc"].includes(order)) q.order_by = order as any;
+
+  // 페이지네이션 커서 적용
+  const cursor = sp.get("cursor");
+  if (cursor) q.cursor = cursor;
+
+  // 데이터 개수 제한 적용
+  const limit = sp.get("limit");
+  if (limit) q.limit = limit;
+
+  // 북마크 필터 적용 (bookmark 또는 all만 허용)
+  const bookmark = sp.get("bookmark");
+  if (bookmark === "bookmark" || bookmark === "all") q.bookmark = bookmark;
+
+  // 완성된 쿼리 객체 반환
+  return q;
+}

--- a/src/pages/profile/ProfileList.tsx
+++ b/src/pages/profile/ProfileList.tsx
@@ -26,8 +26,8 @@ function TwoColLayout({ children }: { children: React.ReactNode }) {
 }
 
 export default function ProfileList() {
-  const [sp] = useSearchParams();
-  const query = buildProfilesQueryFromSearchParams(sp);
+  const [searchParams] = useSearchParams();
+  const query = buildProfilesQueryFromSearchParams(searchParams);
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
     useInfinite<UserProfile>({
       queryKey: ["profiles", query],

--- a/src/pages/profile/ProfileList.tsx
+++ b/src/pages/profile/ProfileList.tsx
@@ -1,3 +1,83 @@
+import { useRef, useEffect } from "react";
+import Filter from "@/components/Filter";
+import ProfileCard from "@/components/ProfileCard";
+import { ProfileListLoading } from "@/components/skeletons/Loaders";
+import InlineDots from "@/components/loading/InlineDots";
+import { useInfinite } from "@/hooks/useInfinite";
+import { useSearchParams } from "react-router";
+import { buildProfilesQueryFromSearchParams } from "@/libs/buildProfilesquery";
+import type { UserProfile } from "@/types/api-res-profile";
+import { fetchProfilesInfinitePage } from "@/pages/profile/api/fetchProfilesInfinite";
+
+const GRID =
+  "grid gap-4 sm:gap-6 lg:gap-8 justify-items-center [grid-template-columns:repeat(auto-fit,minmax(280px,1fr))]";
+
+function TwoColLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="px-2 sm:px-4 lg:px-6">
+      <div className="grid gap-4 lg:gap-6 lg:grid-cols-[280px_1fr]">
+        <aside className="self-start lg:sticky lg:top-20">
+          <Filter filterType="profileFilter" className="w-full max-w-none" />
+        </aside>
+        <section className="relative min-w-0">{children}</section>
+      </div>
+    </div>
+  );
+}
+
 export default function ProfileList() {
-  return <div>ProfileList</div>;
+  const [sp] = useSearchParams();
+  const query = buildProfilesQueryFromSearchParams(sp);
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
+    useInfinite<UserProfile>({
+      queryKey: ["profiles", query],
+      fetchPage: ({ pageParam }) => fetchProfilesInfinitePage({ pageParam, query }),
+    });
+
+  const loaderRef = useRef<HTMLDivElement | null>(null);
+
+  // 마지막 센티널에 닿으면 다음 페이지 로드
+  useEffect(() => {
+    if (!loaderRef.current) return;
+    const el = loaderRef.current;
+
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage();
+        }
+      },
+      { rootMargin: "120px" }
+    );
+
+    io.observe(el);
+    return () => io.unobserve(el);
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  const pages = data?.pages ?? [];
+  const profiles = pages.flatMap((p) => p.items);
+
+  return (
+    <TwoColLayout>
+      <div className={GRID}>
+        {/* 1) 첫 페이지 로딩 때만 스켈레톤 전체 렌더 */}
+        {isLoading ? (
+          <ProfileListLoading count={9} />
+        ) : (
+          <>
+            {/* 2) 누적 카드 렌더 */}
+            {profiles.map((profile) => (
+              <ProfileCard key={profile.user_id} profile={profile} />
+            ))}
+
+            {/* 3) 하단 인디케이터(다음 페이지 로딩 중에만 표시) */}
+            {isFetchingNextPage && <InlineDots />}
+
+            {/* 4) 센티널: 보이기만 하면 다음 페이지 로드 트리거 */}
+            {hasNextPage && <div ref={loaderRef} className="col-span-full h-4" />}
+          </>
+        )}
+      </div>
+    </TwoColLayout>
+  );
 }

--- a/src/pages/profile/api/fetchProfilesInfinite.ts
+++ b/src/pages/profile/api/fetchProfilesInfinite.ts
@@ -1,0 +1,99 @@
+import type { ProfilesQuery } from "@/libs/buildProfilesquery";
+import { mockProfiles } from "@/Mocks/mockProfiles";
+import type { UserProfile } from "@/types/api-res-profile";
+
+/** csv → Set */
+const toIdSet = (csv?: string) =>
+  new Set(
+    (csv ?? "")
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean)
+  );
+
+/** 프로필 전용 필터 */
+function matchesFiltersByQuery(p: UserProfile, q: ProfilesQuery) {
+  // 이름
+  const nickname = q.nickname?.trim().toLowerCase();
+  if (nickname && !p.nickname.toLowerCase().includes(nickname)) return false;
+  // 지역
+  const regionIds = toIdSet(q.region_ids);
+  if (regionIds.size && !p.regions?.some((r) => regionIds.has(r.id))) return false;
+  // 포지션
+  const positionIds = toIdSet(q.position_ids);
+  if (positionIds.size && !p.positions?.some((pl) => positionIds.has(pl.position.id))) return false;
+  // 선호 장르
+  const genreIds = toIdSet(q.genre_ids);
+  if (genreIds.size && !p.genres?.some((g) => genreIds.has(g.id))) return false;
+  // 경력
+  const expIds = toIdSet(q.experience_level_ids);
+  if (expIds.size && !p.positions?.some((pl) => expIds.has(pl.experience_level.id))) return false;
+  // 북마크
+  if (q.bookmark === "bookmark" && !p.is_bookmarked) return false;
+
+  return true;
+}
+
+/** (선택) 정렬 – 프로필 UI에서 정렬 숨겼다면 제거해도 됨 */
+function sortProfilesByQuery(arr: UserProfile[], q: ProfilesQuery) {
+  const sortBy = q.sort_by;
+  const orderBy = q.order_by ?? "desc";
+  const copy = [...arr];
+
+  if (sortBy === "bookmarks")
+    copy.sort((a, b) => Number(b.is_bookmarked) - Number(a.is_bookmarked));
+  else if (sortBy === "latest") copy.sort((a, b) => a.nickname.localeCompare(b.nickname));
+  // views는 목데이터에 없음
+
+  if (orderBy === "asc") copy.reverse();
+  return copy;
+}
+
+/** 📌 프로필 전용 페이지 로더
+ * - 범용 훅이 요구하는 표준 페이지 { items, next_cursor }로 변환해서 반환
+ */
+export async function fetchProfilesInfinitePage({
+  pageParam = "0",
+  query,
+}: {
+  pageParam?: string;
+  query: ProfilesQuery;
+}): Promise<{ items: UserProfile[]; next_cursor?: string }> {
+  // 원본 데이터 (배열/객체 모두 안전 처리)
+  const source: UserProfile[] = Array.isArray(mockProfiles)
+    ? mockProfiles
+    : ((mockProfiles as any)?.profiles ?? []);
+
+  // 필터 + (선택)정렬
+  const filtered = source.filter((p) => matchesFiltersByQuery(p, query));
+  const sorted = sortProfilesByQuery(filtered, query);
+
+  // 페이지네이션
+  const limit = Number(query.limit ?? 10);
+  const start = Number(pageParam);
+  const pageItems = sorted.slice(start, start + limit);
+  const next = start + limit < sorted.length ? String(start + limit) : "";
+
+  // 로딩 시뮬레이션
+  await new Promise((res) => setTimeout(res, 300));
+
+  // ✅ 범용 훅 표준 형태로 반환
+  return { items: pageItems, next_cursor: next };
+}
+
+/** 실제 API 버전
+export async function fetchProfilesInfinitePageApi({
+  pageParam = "0",
+  query,
+}: {
+  pageParam?: string;
+  query: ProfilesQuery;
+}) {
+  const params = new URLSearchParams({ ...query, cursor: String(pageParam) });
+  const res = await fetch(`/api/v1/profiles?${params.toString()}`, { credentials: "include" });
+  if (!res.ok) throw new Error("프로필 불러오기 실패");
+  // 서버 응답이 UserList라면 적절히 매핑
+  const data = (await res.json()) as UserList; // { profiles, next_cursor }
+  return { items: data.profiles, next_cursor: data.next_cursor };
+}
+*/

--- a/src/types/api-res-common.d.ts
+++ b/src/types/api-res-common.d.ts
@@ -35,12 +35,12 @@ export interface Genre {
   name: string;
 }
 
-interface ExperienceLevel {
+export interface ExperienceLevel {
   id: string;
   name: string;
 }
 
-interface Region {
+export interface Region {
   id: string;
   name: string;
 }

--- a/src/types/api-res-profile.d.ts
+++ b/src/types/api-res-profile.d.ts
@@ -18,14 +18,8 @@ export interface UserList {
 
 // GET /api/v1/profiles/{user_id}
 export type UserProfileDetail = PublicUserProfileDetail | PrivateUserProfileDetail;
-export interface BaseUserProfileDetail {
-  nickname: string;
-  image_url: string;
-  is_bookmarked: boolean;
+export interface BaseUserProfileDetail extends UserProfile {
   is_public: boolean;
-  regions: Region[];
-  positions: PositionAndLevel[];
-  genres: Genre[];
 }
 export interface PublicUserProfileDetail extends BaseUserProfileDetail {
   is_public: true;


### PR DESCRIPTION
## 📌 개요

프로필 리스트 제작, 필터 적용 및 무한 스크롤 구현

## ✅ 작업 내용

- 프로필 전용 필터로 따로 분리
- 필터를 프로필 리스트에 적용
- 무한 스크롤 구현
- 무한 스크롤 전용 Inline dots 제작
- 게시글 카드가 푸터를 무시하고 아래로 내려가는 문제가 있어 수정
- 프로필 카드 약간 수정

## 🔍 관련 이슈

Closes #108 
## 📸 스크린샷 (선택)

<img width="1485" height="1264" alt="스크린샷 2025-08-13 150130" src="https://github.com/user-attachments/assets/90573267-157a-4e64-a693-2ef24005cc93" />
<img width="499" height="1265" alt="스크린샷 2025-08-13 150137" src="https://github.com/user-attachments/assets/5fbd0924-d121-4cbc-9614-b10594e96544" />
<img width="2559" height="1273" alt="스크린샷 2025-08-13 150146" src="https://github.com/user-attachments/assets/22d57a39-e137-479f-b69b-012d71be75a0" />
<img width="2559" height="1273" alt="스크린샷 2025-08-13 150206" src="https://github.com/user-attachments/assets/32cba5d5-e247-4d27-8149-27cc86773802" />

