### PR TITLE
#154 header 패딩 및 배경 수정

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -36,7 +36,7 @@ const Header: FC = () => {
       className={cn(
         "fixed top-0  z-40 flex justify-between items-center w-full h-[52px] sm:h-[80px] px-4 sm:px-6 sm:py-0 bg-transparent sm:shadow-none",
         isBurgerOpen && "shadow-lg",
-        !isAuthPage && "bg-bg-primary"
+        !isAuthPage && "bg-white"
       )}
     >
       {/* 메인 로고 */}

--- a/src/components/layout/RootLayout.tsx
+++ b/src/components/layout/RootLayout.tsx
@@ -6,7 +6,7 @@ export default function RootLayout() {
   return (
     <div className="flex flex-col min-h-screen">
       <Header />
-      <main className="flex-1  pt-[52px] sm:pt-[80px]">
+      <main className="flex-1  pt-[52px] sm:pt-[110px]">
         <Outlet />
       </main>
       <Footer />

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -29,7 +29,7 @@ const LogIn = () => {
   };
 
   return (
-    <div className="flex items-center justify-center w-screen min-h-screen bg-[url('/background.jpg')] bg-cover sm:bg-fixed relative before:absolute before:inset-0 before:bg-black/50 pt-[120px] pb-[80px]">
+    <div className="flex items-center justify-center w-screen min-h-screen bg-[url('/background.jpg')] bg-cover -mt-[52px] sm:-mt-[110px] sm:bg-fixed relative before:absolute before:inset-0 before:bg-black/50 pt-[120px] pb-[80px]">
       {/* 폼 컨테이너 */}
       <form
         noValidate

--- a/src/pages/auth/SignUp.tsx
+++ b/src/pages/auth/SignUp.tsx
@@ -41,7 +41,7 @@ const SignUp = () => {
   const handleGoogleSignUp = (): void => {};
 
   return (
-    <div className="flex items-center justify-center w-screen min-h-screen bg-[url('/background.jpg')] bg-cover sm:bg-fixed relative before:absolute before:inset-0 before:bg-black/50 pt-[120px] pb-[80px]">
+    <div className="flex items-center justify-center w-screen min-h-screen bg-[url('/background.jpg')] bg-cover -mt-[52px] sm:-mt-[110px] sm:bg-fixed relative before:absolute before:inset-0 before:bg-black/50 pt-[120px] pb-[80px]">
       {/* 폼 컨테이너 */}
       <form
         noValidate


### PR DESCRIPTION
## 📌 개요
- 로그인, 회원가입 페이지에 헤더부분 패딩이 생기는 문제 해결

## ✅ 작업 내용

- 로그인, 회원가입 페이지에 -pt을 각각 넣어줌

## 🔍 관련 이슈

Closes #154 

## 📸 스크린샷 (선택)
<img width="1906" height="899" alt="image" src="https://github.com/user-attachments/assets/41707a24-2e9d-4639-bef5-50fb2d214f02" />
<img width="1900" height="895" alt="image" src="https://github.com/user-attachments/assets/e7a776cb-b97d-422b-aced-e2d6e87ffc1e" />

