### PR TITLE
#151 구인글 상세 페이지

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import SignUp from "@/pages/auth/SignUp";
 import RecruitmentList from "@/pages/recruitment-post/RecruitmentList";
 import ProfileList from "@/pages/profile/ProfileList";
 import RecruitmentNewPost from "@/pages/recruitment-post/RecruitmentNewPost";
+import RecruitmentDetail from "@/pages/recruitment-post/RecruitmentDetail";
 
 function App() {
   return (
@@ -18,6 +19,7 @@ function App() {
 
         <Route path="/recruitment-post">
           <Route index element={<RecruitmentList />} />
+          <Route path="/recruitment-post/:postId" element={<RecruitmentDetail />} />
           <Route path="/recruitment-post/new-post" element={<RecruitmentNewPost />} />
         </Route>
 

--- a/src/components/commentUI/CommentInput.tsx
+++ b/src/components/commentUI/CommentInput.tsx
@@ -1,0 +1,51 @@
+import Text from "@/components/text/Text";
+import { cn } from "@/libs/utils";
+import type { ComponentPropsWithoutRef } from "react";
+import Input from "@/components/input/AuthInput";
+import Button from "../Button";
+import z from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+const commentSchema = z.object({
+  comment: z.string().min(1, "한 글자 이상 입력해주세요."),
+});
+
+type TCommentSchema = z.infer<typeof commentSchema>;
+
+interface CommentInputProps extends Omit<ComponentPropsWithoutRef<"input">, "type"> {
+  postId: string;
+}
+
+export default function CommentInput({ postId, className = "", ...rest }: CommentInputProps) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<TCommentSchema>({ resolver: zodResolver(commentSchema) });
+
+  const onSubmit = (form: TCommentSchema) => {
+    console.log(form);
+  };
+
+  return (
+    <form
+      className={cn("text-text-primary flex flex-col justify-start  space-y-1", className)}
+      onSubmit={handleSubmit(onSubmit)}
+    >
+      <label htmlFor={`${postId}-comment-input`}>
+        <Text variant="label">댓글</Text>
+      </label>
+      <Input
+        id={`${postId}-comment-input`}
+        type="text"
+        {...rest}
+        {...register("comment")}
+        error={errors.comment?.message}
+      />
+      <Button type="submit">
+        <Text className="text-text-on-dark">댓글 작성</Text>
+      </Button>
+    </form>
+  );
+}

--- a/src/pages/recruitment-post/RecruitmentDetail.tsx
+++ b/src/pages/recruitment-post/RecruitmentDetail.tsx
@@ -1,0 +1,7 @@
+import { useParams } from "react-router";
+
+export default function RecruitmentDetail() {
+  const { postId } = useParams();
+
+  return <div>RecruitmentDetail of {postId}</div>;
+}

--- a/src/pages/recruitment-post/RecruitmentDetail.tsx
+++ b/src/pages/recruitment-post/RecruitmentDetail.tsx
@@ -1,8 +1,10 @@
 import Badge from "@/components/Badge";
 import BookmarkButton from "@/components/BookmarkBtn";
+import CommentUI from "@/components/commentUI/CommentUI";
 import H1 from "@/components/text/H1";
 import Text from "@/components/text/Text";
 import { getTimeDiff } from "@/libs/utils";
+import type { CommentList } from "@/types/api-res-comment";
 import type { PostDetail } from "@/types/api-res-recruitment";
 import { useEffect, useState } from "react";
 //import { useParams } from "react-router";
@@ -83,6 +85,59 @@ const dummyPostData: PostDetail = {
   image_url: "https://dummyimage.com/600x400/000/fff​",
 };
 
+//실제론 api로 호출
+const dummyCommenList: CommentList = {
+  next_cursor: "cursor_12345",
+  comments: [
+    {
+      id: "comment_1",
+      content: "첫 번째 댓글입니다.",
+      created_at: "2025-08-12T10:30:00Z",
+      post: {
+        id: "post_1",
+        title: "첫 번째 게시글 제목",
+      },
+      children: [
+        {
+          id: "comment_1_1",
+          content: "첫 번째 댓글의 대댓글입니다.",
+          created_at: "2025-08-12T11:00:00Z",
+          post: {
+            id: "post_1",
+            title: "첫 번째 게시글 제목",
+          },
+          children: [],
+          is_owner: false,
+          author: {
+            user_id: "user_002",
+            nickname: "김한주",
+          },
+        },
+      ],
+      is_owner: true,
+      author: {
+        user_id: "user_001",
+        nickname: "유다빈",
+      },
+    },
+    {
+      id: "comment_2",
+      content: "두 번째 댓글입니다.",
+      created_at: "2025-08-12T12:15:00Z",
+      post: {
+        id: "post_2",
+        title: "두 번째 게시글 제목",
+      },
+      children: [],
+      is_owner: false,
+      author: {
+        user_id: "user_003",
+        nickname: "최웅희",
+      },
+    },
+  ],
+};
+
 export default function RecruitmentDetail() {
   //const { postId } = useParams();
   const {
@@ -115,107 +170,120 @@ export default function RecruitmentDetail() {
 
   return (
     <div className="bg-bg-primary text-text-primary p-2 flex justify-center ">
-      <div className="flex flex-col max-w-5xl">
-        <div className="flex w-full justify-between items-center">
-          <H1 className="truncate w-full">{title}</H1>
-          <BookmarkButton isBookmarked={isBookmarked} size="sm" userId={userId} />
-        </div>
+      <div className="flex flex-col gap-3 items-center lg:flex-row lg:items-start">
+        <div className="flex flex-col max-w-2xl">
+          <div className="flex w-full justify-between items-center">
+            <H1 className="truncate w-full">{title}</H1>
+            <BookmarkButton isBookmarked={isBookmarked} size="sm" userId={userId} />
+          </div>
 
-        <div className="flex justify-between items-center w-full mt-2 mb-3">
-          {isClosed ? (
-            <Badge size="sm" className="bg-primary-thick">
-              <Text variant="label" className="text-text-on-dark">
-                마감
-              </Text>
-            </Badge>
-          ) : (
-            <Badge size="sm" color="secondary">
-              모집중
-            </Badge>
-          )}
-          <div>
-            <Text variant="subText">{nickname}</Text>
-            <Text variant="subText">·</Text>
-            <Text variant="subText">{`${timeDiff}`}</Text>
+          <div className="flex justify-between items-center w-full mt-2 mb-3">
+            {isClosed ? (
+              <Badge size="sm" className="bg-primary-thick">
+                <Text variant="label" className="text-text-on-dark">
+                  마감
+                </Text>
+              </Badge>
+            ) : (
+              <Badge size="sm" color="secondary">
+                모집중
+              </Badge>
+            )}
+            <div>
+              <Text variant="subText">{nickname}</Text>
+              <Text variant="subText">·</Text>
+              <Text variant="subText">{`${timeDiff}`}</Text>
+            </div>
+          </div>
+
+          <div className="flex flex-col space-y-3 justify-start items-start">
+            {bandName ? <Text>{`밴드 이름: ${bandName}`}</Text> : null}
+            {bandComposition ? <Text>{`밴드 구성: ${bandComposition}`}</Text> : null}
+            {activityTime ? <Text>{`주 활동 시간: ${activityTime}`}</Text> : null}
+            {practiceFrequencyTime ? <Text>{`활동 주기: ${practiceFrequencyTime}`}</Text> : null}
+            {contactInfo ? <Text>{`연락 방법: ${contactInfo}`}</Text> : null}
+            {applicationMethod ? <Text>{`지원 방법: ${applicationMethod}`}</Text> : null}
+            {otherCondition ? <Text>{`기타 조건: ${otherCondition}`}</Text> : null}
+
+            {positions ? (
+              <div className="flex flex-col space-y-0.5">
+                {positions.map((position, index) => {
+                  const {
+                    position_name: positionName,
+                    experience_level_name: experienceLevelName,
+                  } = position;
+                  return (
+                    <div
+                      className="flex flex-row justify-start items-center space-x-1.5"
+                      key={index}
+                    >
+                      <Text>{`모집 포지션 ${index + 1}`}</Text>
+                      <Badge size="sm" color="primarySoft">
+                        {positionName}
+                      </Badge>
+                      <Badge size="sm" color="primarySoft">
+                        {experienceLevelName}
+                      </Badge>
+                    </div>
+                  );
+                })}
+              </div>
+            ) : null}
+
+            {genres ? (
+              <div className="flex flex-row justify-start items-center space-x-1.5">
+                <Text>선호 장르</Text>
+                {genres.map(({ name, id }) => (
+                  <Badge size="sm" color="primarySoft" key={id}>
+                    {name}
+                  </Badge>
+                ))}
+              </div>
+            ) : null}
+
+            {regions ? (
+              <div className="flex flex-row justify-start items-center space-x-1.5">
+                <Text>활동 지역</Text>
+                {regions.map(({ name, id }) => (
+                  <Badge size="sm" color="primarySoft" key={id}>
+                    {name}
+                  </Badge>
+                ))}
+              </div>
+            ) : null}
+
+            {orientation ? (
+              <div className="flex flex-row justify-start items-center space-x-1.5">
+                <Text>지향</Text>
+                <Badge size="sm" color="primarySoft">
+                  {orientation.name}
+                </Badge>
+              </div>
+            ) : null}
+
+            {recruitmentType ? (
+              <div className="flex flex-row justify-start items-center space-x-1.5">
+                <Text>밴드 형태</Text>
+                <Badge size="sm" color="primarySoft">
+                  {recruitmentType.name}
+                </Badge>
+              </div>
+            ) : null}
+
+            <Text>{content}</Text>
+
+            {imageUrl ? (
+              <div className="w-full flex justify-center">
+                <img src={imageUrl} className="rounded-lg w-[512px]" />
+              </div>
+            ) : null}
           </div>
         </div>
 
-        <div className="flex flex-col space-y-3 justify-start items-start">
-          {bandName ? <Text>{`밴드 이름: ${bandName}`}</Text> : null}
-          {bandComposition ? <Text>{`밴드 구성: ${bandComposition}`}</Text> : null}
-          {activityTime ? <Text>{`주 활동 시간: ${activityTime}`}</Text> : null}
-          {practiceFrequencyTime ? <Text>{`활동 주기: ${practiceFrequencyTime}`}</Text> : null}
-          {contactInfo ? <Text>{`연락 방법: ${contactInfo}`}</Text> : null}
-          {applicationMethod ? <Text>{`지원 방법: ${applicationMethod}`}</Text> : null}
-          {otherCondition ? <Text>{`기타 조건: ${otherCondition}`}</Text> : null}
-
-          {positions ? (
-            <div className="flex flex-col space-y-0.5">
-              {positions.map((position, index) => {
-                const { position_name: positionName, experience_level_name: experienceLevelName } =
-                  position;
-                return (
-                  <div className="flex flex-row justify-start items-center space-x-1.5" key={index}>
-                    <Text>{`모집 포지션 ${index + 1}`}</Text>
-                    <Badge size="sm" color="primarySoft">
-                      {positionName}
-                    </Badge>
-                    <Badge size="sm" color="primarySoft">
-                      {experienceLevelName}
-                    </Badge>
-                  </div>
-                );
-              })}
-            </div>
-          ) : null}
-
-          {genres ? (
-            <div className="flex flex-row justify-start items-center space-x-1.5">
-              <Text>선호 장르</Text>
-              {genres.map(({ name, id }) => (
-                <Badge size="sm" color="primarySoft" key={id}>
-                  {name}
-                </Badge>
-              ))}
-            </div>
-          ) : null}
-
-          {regions ? (
-            <div className="flex flex-row justify-start items-center space-x-1.5">
-              <Text>활동 지역</Text>
-              {regions.map(({ name, id }) => (
-                <Badge size="sm" color="primarySoft" key={id}>
-                  {name}
-                </Badge>
-              ))}
-            </div>
-          ) : null}
-
-          {orientation ? (
-            <div className="flex flex-row justify-start items-center space-x-1.5">
-              <Text>지향</Text>
-              <Badge size="sm" color="primarySoft">
-                {orientation.name}
-              </Badge>
-            </div>
-          ) : null}
-
-          {recruitmentType ? (
-            <div className="flex flex-row justify-start items-center space-x-1.5">
-              <Text>밴드 형태</Text>
-              <Badge size="sm" color="primarySoft">
-                {recruitmentType.name}
-              </Badge>
-            </div>
-          ) : null}
-
-          <Text>{content}</Text>
-
-          {imageUrl ? (
-            <div className="w-full flex justify-center">
-              <img src={imageUrl} className="rounded-lg w-[512px]" />
-            </div>
-          ) : null}
+        <div className="flex flex-col items-start w-full max-w-[512px] space-y-1">
+          {dummyCommenList.comments.map((comment) => (
+            <CommentUI comment={comment} key={comment.id} className="w-full" />
+          ))}
         </div>
       </div>
     </div>

--- a/src/pages/recruitment-post/RecruitmentDetail.tsx
+++ b/src/pages/recruitment-post/RecruitmentDetail.tsx
@@ -8,10 +8,13 @@ import { getTimeDiff } from "@/libs/utils";
 import type { CommentList } from "@/types/api-res-comment";
 import type { PostDetail } from "@/types/api-res-recruitment";
 import { useEffect, useState } from "react";
-import { useParams } from "react-router";
+import { Link, useParams } from "react-router";
 import EyeIcon from "@/components/icons/EyeIcon";
 import CommentIcon from "@/components/icons/CommentIcon";
 import BookmarkIcon from "@/components/icons/BookmarkIcon";
+import Button from "@/components/Button";
+import { Modal, ModalClose, ModalContent, ModalTrigger } from "@/components/Modal";
+import H3 from "@/components/text/H3";
 
 //더미 포스트 데이터 실제론 api 준비
 const dummyPostData: PostDetail = {
@@ -22,7 +25,7 @@ const dummyPostData: PostDetail = {
     nickname: "이재현",
   },
   is_closed: false,
-  is_owner: false,
+  is_owner: true,
   is_bookmarked: true,
 
   created_at: "2025-08-12T11:00:00Z",
@@ -168,6 +171,7 @@ export default function RecruitmentDetail() {
     views_count: viewsCount,
     comments_count: commentsCount,
     bookmarks_count: bookmarksCount,
+    is_owner: isOwner,
   } = dummyPostData;
 
   const [timeDiff, setTimeDiff] = useState("");
@@ -303,6 +307,17 @@ export default function RecruitmentDetail() {
               <BookmarkIcon />
               <Text variant="subText">{bookmarksCount}</Text>
             </div>
+
+            {isOwner ? (
+              <div className="flex items-center justify-center space-x-2 w-full">
+                <Link to="#">
+                  <Button color="secondary" variant="outline">
+                    <Text>수정하기</Text>
+                  </Button>
+                </Link>
+                <TogglePostStatusModal isClosed={isClosed} postId={postId} />
+              </div>
+            ) : null}
           </div>
         </div>
 
@@ -318,5 +333,46 @@ export default function RecruitmentDetail() {
         </div>
       </div>
     </div>
+  );
+}
+
+interface TogglePostStatusModalProps {
+  isClosed: boolean;
+  postId: string;
+}
+
+function TogglePostStatusModal({ isClosed, postId }: TogglePostStatusModalProps) {
+  const handleClick = () => {
+    //실제 api 연결
+    console.log(`${postId} 마감 상태 변경`);
+  };
+
+  return (
+    <Modal>
+      <ModalTrigger>
+        <Button color="error" variant="outline">
+          <Text>{isClosed ? "다시 열기" : "마감하기"}</Text>
+        </Button>
+      </ModalTrigger>
+      <ModalContent className="flex flex-col items-start justify-start p-2 space-y-5">
+        <H3 className="text-text-primary">
+          {isClosed ? "다시 열시겠습니까?" : "마감하시겠습니까?"}
+        </H3>
+        <div className="flex justify-end items-center w-full space-x-2">
+          <ModalClose>
+            <Button variant="outline" color="error">
+              <Text variant="subText" className="text-text-primary">
+                취소
+              </Text>
+            </Button>
+          </ModalClose>
+          <Button color="error" onClick={handleClick}>
+            <Text className="text-text-on-dark" variant="subText">
+              {isClosed ? "다시 열기" : "마감하기"}
+            </Text>{" "}
+          </Button>
+        </div>
+      </ModalContent>
+    </Modal>
   );
 }

--- a/src/pages/recruitment-post/RecruitmentDetail.tsx
+++ b/src/pages/recruitment-post/RecruitmentDetail.tsx
@@ -9,6 +9,9 @@ import type { CommentList } from "@/types/api-res-comment";
 import type { PostDetail } from "@/types/api-res-recruitment";
 import { useEffect, useState } from "react";
 import { useParams } from "react-router";
+import EyeIcon from "@/components/icons/EyeIcon";
+import CommentIcon from "@/components/icons/CommentIcon";
+import BookmarkIcon from "@/components/icons/BookmarkIcon";
 
 //더미 포스트 데이터 실제론 api 준비
 const dummyPostData: PostDetail = {
@@ -162,6 +165,9 @@ export default function RecruitmentDetail() {
     regions,
     content,
     image_url: imageUrl,
+    views_count: viewsCount,
+    comments_count: commentsCount,
+    bookmarks_count: bookmarksCount,
   } = dummyPostData;
 
   const [timeDiff, setTimeDiff] = useState("");
@@ -288,6 +294,15 @@ export default function RecruitmentDetail() {
                 <img src={imageUrl} className="rounded-lg w-[512px]" />
               </div>
             ) : null}
+
+            <div className="flex space-x-1 justify-center items-center">
+              <EyeIcon />
+              <Text variant="subText">{viewsCount}</Text>
+              <CommentIcon />
+              <Text variant="subText">{commentsCount}</Text>
+              <BookmarkIcon />
+              <Text variant="subText">{bookmarksCount}</Text>
+            </div>
           </div>
         </div>
 

--- a/src/pages/recruitment-post/RecruitmentDetail.tsx
+++ b/src/pages/recruitment-post/RecruitmentDetail.tsx
@@ -79,6 +79,8 @@ const dummyPostData: PostDetail = {
       name: "서울 남부",
     },
   ],
+
+  image_url: "https://dummyimage.com/600x400/000/fff​",
 };
 
 export default function RecruitmentDetail() {
@@ -112,8 +114,8 @@ export default function RecruitmentDetail() {
   }, [createdAt, setTimeDiff]);
 
   return (
-    <div className="bg-bg-primary text-text-primary p-2">
-      <div className="flex flex-col">
+    <div className="bg-bg-primary text-text-primary p-2 flex justify-center ">
+      <div className="flex flex-col max-w-5xl">
         <div className="flex w-full justify-between items-center">
           <H1 className="truncate w-full">{title}</H1>
           <BookmarkButton isBookmarked={isBookmarked} size="sm" userId={userId} />
@@ -138,7 +140,7 @@ export default function RecruitmentDetail() {
           </div>
         </div>
 
-        <div className="flex flex-col space-y-1 justify-start items-start">
+        <div className="flex flex-col space-y-3 justify-start items-start">
           {bandName ? <Text>{`밴드 이름: ${bandName}`}</Text> : null}
           {bandComposition ? <Text>{`밴드 구성: ${bandComposition}`}</Text> : null}
           {activityTime ? <Text>{`주 활동 시간: ${activityTime}`}</Text> : null}
@@ -153,7 +155,7 @@ export default function RecruitmentDetail() {
                 const { position_name: positionName, experience_level_name: experienceLevelName } =
                   position;
                 return (
-                  <div className="flex flex-row justify-start items-center space-x-0.5" key={index}>
+                  <div className="flex flex-row justify-start items-center space-x-1.5" key={index}>
                     <Text>{`모집 포지션 ${index + 1}`}</Text>
                     <Badge size="sm" color="primarySoft">
                       {positionName}
@@ -168,7 +170,7 @@ export default function RecruitmentDetail() {
           ) : null}
 
           {genres ? (
-            <div className="flex flex-row justify-start items-center space-x-0.5">
+            <div className="flex flex-row justify-start items-center space-x-1.5">
               <Text>선호 장르</Text>
               {genres.map(({ name, id }) => (
                 <Badge size="sm" color="primarySoft" key={id}>
@@ -179,7 +181,7 @@ export default function RecruitmentDetail() {
           ) : null}
 
           {regions ? (
-            <div className="flex flex-row justify-start items-center space-x-0.5">
+            <div className="flex flex-row justify-start items-center space-x-1.5">
               <Text>활동 지역</Text>
               {regions.map(({ name, id }) => (
                 <Badge size="sm" color="primarySoft" key={id}>
@@ -190,7 +192,7 @@ export default function RecruitmentDetail() {
           ) : null}
 
           {orientation ? (
-            <div className="flex flex-row justify-start items-center space-x-0.5">
+            <div className="flex flex-row justify-start items-center space-x-1.5">
               <Text>지향</Text>
               <Badge size="sm" color="primarySoft">
                 {orientation.name}
@@ -199,7 +201,7 @@ export default function RecruitmentDetail() {
           ) : null}
 
           {recruitmentType ? (
-            <div className="flex flex-row justify-start items-center space-x-0.5">
+            <div className="flex flex-row justify-start items-center space-x-1.5">
               <Text>밴드 형태</Text>
               <Badge size="sm" color="primarySoft">
                 {recruitmentType.name}
@@ -209,7 +211,11 @@ export default function RecruitmentDetail() {
 
           <Text>{content}</Text>
 
-          {imageUrl ? <img src={imageUrl} className="rounded-lg" /> : null}
+          {imageUrl ? (
+            <div className="w-full flex justify-center">
+              <img src={imageUrl} className="rounded-lg w-[512px]" />
+            </div>
+          ) : null}
         </div>
       </div>
     </div>

--- a/src/pages/recruitment-post/RecruitmentDetail.tsx
+++ b/src/pages/recruitment-post/RecruitmentDetail.tsx
@@ -1,4 +1,73 @@
+import type { PostDetail } from "@/types/api-res-recruitment";
 import { useParams } from "react-router";
+
+//더미 포스트 데이터 실제론 api 준비
+const dummyPostData: PostDetail = {
+  id: "1",
+  title: "유지민 밴드에서 키보드를 찾습니다!",
+  author: {
+    id: "1111",
+    nickname: "이재현",
+  },
+  is_closed: false,
+  is_owner: false,
+  is_bookmarked: true,
+
+  created_at: "2025-08-12T11:00:00Z",
+
+  views_count: 100,
+  comments_count: 10,
+  bookmarks_count: 5,
+
+  content:
+    "서울 홍대에서 활동 하고 있는 유지빈 밴드입니다. 취미 지향 직장인 밴드입니다. 합주는 주로 주말에 격주로 진행합니다. 멤버는 현재 남보컬 겸 세컨 기타, 리드 기타, 드럼, 베이스로 이루어져 있습니다. 관심 있으시면 댓글이나 아래 이메일로 편하게 연락주세요! example@example.com",
+
+  band_name: "유지민 밴드",
+  band_composition: "남보컬 겸 세컨 기타, 리드 기타, 드럼, 베이스",
+  activity_time: "월요일 오후 8시, 주말",
+  practice_frequency_time: "격주로 주 1회",
+  contact_info: "examle@example.com",
+  application_method: "대면 오디션",
+  other_conditions: "공연 경험 있으면 우대",
+
+  recruitment_type: { id: "asdfadsfa", name: "고정 밴드" },
+
+  genres: [
+    {
+      id: "143125235",
+      name: "인디락",
+    },
+    {
+      id: "14313asdfa25235",
+      name: "하드락",
+    },
+  ],
+
+  orientation: {
+    id: "asdfagsdfjoppjo",
+    name: "취미",
+  },
+
+  positions: [
+    {
+      position_id: "1222",
+      position_name: "키보드",
+      experience_level_id: "312345",
+      experience_level_name: "취미 1년 이상 3년 이하",
+    },
+  ],
+
+  regions: [
+    {
+      id: "12415r123t5234",
+      name: "서울 서부",
+    },
+    {
+      id: "12r123t5234",
+      name: "서울 남부",
+    },
+  ],
+};
 
 export default function RecruitmentDetail() {
   const { postId } = useParams();

--- a/src/pages/recruitment-post/RecruitmentDetail.tsx
+++ b/src/pages/recruitment-post/RecruitmentDetail.tsx
@@ -1,5 +1,11 @@
+import Badge from "@/components/Badge";
+import BookmarkButton from "@/components/BookmarkBtn";
+import H1 from "@/components/text/H1";
+import Text from "@/components/text/Text";
+import { getTimeDiff } from "@/libs/utils";
 import type { PostDetail } from "@/types/api-res-recruitment";
-import { useParams } from "react-router";
+import { useEffect, useState } from "react";
+//import { useParams } from "react-router";
 
 //더미 포스트 데이터 실제론 api 준비
 const dummyPostData: PostDetail = {
@@ -55,6 +61,12 @@ const dummyPostData: PostDetail = {
       experience_level_id: "312345",
       experience_level_name: "취미 1년 이상 3년 이하",
     },
+    {
+      position_id: "12234t622",
+      position_name: "여보컬",
+      experience_level_id: "312315545",
+      experience_level_name: "취미 1년 이상 3년 이하",
+    },
   ],
 
   regions: [
@@ -70,7 +82,136 @@ const dummyPostData: PostDetail = {
 };
 
 export default function RecruitmentDetail() {
-  const { postId } = useParams();
+  //const { postId } = useParams();
+  const {
+    title,
+    is_bookmarked: isBookmarked,
+    author: { id: userId, nickname },
+    created_at: createdAt,
+    is_closed: isClosed,
+    band_name: bandName,
+    band_composition: bandComposition,
+    activity_time: activityTime,
+    practice_frequency_time: practiceFrequencyTime,
+    application_method: applicationMethod,
+    contact_info: contactInfo,
+    other_conditions: otherCondition,
+    recruitment_type: recruitmentType,
+    genres,
+    orientation,
+    positions,
+    regions,
+    content,
+    image_url: imageUrl,
+  } = dummyPostData;
 
-  return <div>RecruitmentDetail of {postId}</div>;
+  const [timeDiff, setTimeDiff] = useState("");
+
+  useEffect(() => {
+    setTimeDiff(getTimeDiff(new Date(createdAt)));
+  }, [createdAt, setTimeDiff]);
+
+  return (
+    <div className="bg-bg-primary text-text-primary p-2">
+      <div className="flex flex-col">
+        <div className="flex w-full justify-between items-center">
+          <H1 className="truncate w-full">{title}</H1>
+          <BookmarkButton isBookmarked={isBookmarked} size="sm" userId={userId} />
+        </div>
+
+        <div className="flex justify-between items-center w-full mt-2 mb-3">
+          {isClosed ? (
+            <Badge size="sm" className="bg-primary-thick">
+              <Text variant="label" className="text-text-on-dark">
+                마감
+              </Text>
+            </Badge>
+          ) : (
+            <Badge size="sm" color="secondary">
+              모집중
+            </Badge>
+          )}
+          <div>
+            <Text variant="subText">{nickname}</Text>
+            <Text variant="subText">·</Text>
+            <Text variant="subText">{`${timeDiff}`}</Text>
+          </div>
+        </div>
+
+        <div className="flex flex-col space-y-1 justify-start items-start">
+          {bandName ? <Text>{`밴드 이름: ${bandName}`}</Text> : null}
+          {bandComposition ? <Text>{`밴드 구성: ${bandComposition}`}</Text> : null}
+          {activityTime ? <Text>{`주 활동 시간: ${activityTime}`}</Text> : null}
+          {practiceFrequencyTime ? <Text>{`활동 주기: ${practiceFrequencyTime}`}</Text> : null}
+          {contactInfo ? <Text>{`연락 방법: ${contactInfo}`}</Text> : null}
+          {applicationMethod ? <Text>{`지원 방법: ${applicationMethod}`}</Text> : null}
+          {otherCondition ? <Text>{`기타 조건: ${otherCondition}`}</Text> : null}
+
+          {positions ? (
+            <div className="flex flex-col space-y-0.5">
+              {positions.map((position, index) => {
+                const { position_name: positionName, experience_level_name: experienceLevelName } =
+                  position;
+                return (
+                  <div className="flex flex-row justify-start items-center space-x-0.5" key={index}>
+                    <Text>{`모집 포지션 ${index + 1}`}</Text>
+                    <Badge size="sm" color="primarySoft">
+                      {positionName}
+                    </Badge>
+                    <Badge size="sm" color="primarySoft">
+                      {experienceLevelName}
+                    </Badge>
+                  </div>
+                );
+              })}
+            </div>
+          ) : null}
+
+          {genres ? (
+            <div className="flex flex-row justify-start items-center space-x-0.5">
+              <Text>선호 장르</Text>
+              {genres.map(({ name, id }) => (
+                <Badge size="sm" color="primarySoft" key={id}>
+                  {name}
+                </Badge>
+              ))}
+            </div>
+          ) : null}
+
+          {regions ? (
+            <div className="flex flex-row justify-start items-center space-x-0.5">
+              <Text>활동 지역</Text>
+              {regions.map(({ name, id }) => (
+                <Badge size="sm" color="primarySoft" key={id}>
+                  {name}
+                </Badge>
+              ))}
+            </div>
+          ) : null}
+
+          {orientation ? (
+            <div className="flex flex-row justify-start items-center space-x-0.5">
+              <Text>지향</Text>
+              <Badge size="sm" color="primarySoft">
+                {orientation.name}
+              </Badge>
+            </div>
+          ) : null}
+
+          {recruitmentType ? (
+            <div className="flex flex-row justify-start items-center space-x-0.5">
+              <Text>밴드 형태</Text>
+              <Badge size="sm" color="primarySoft">
+                {recruitmentType.name}
+              </Badge>
+            </div>
+          ) : null}
+
+          <Text>{content}</Text>
+
+          {imageUrl ? <img src={imageUrl} className="rounded-lg" /> : null}
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/pages/recruitment-post/RecruitmentDetail.tsx
+++ b/src/pages/recruitment-post/RecruitmentDetail.tsx
@@ -1,5 +1,6 @@
 import Badge from "@/components/Badge";
 import BookmarkButton from "@/components/BookmarkBtn";
+import CommentInput from "@/components/commentUI/CommentInput";
 import CommentUI from "@/components/commentUI/CommentUI";
 import H1 from "@/components/text/H1";
 import Text from "@/components/text/Text";
@@ -7,7 +8,7 @@ import { getTimeDiff } from "@/libs/utils";
 import type { CommentList } from "@/types/api-res-comment";
 import type { PostDetail } from "@/types/api-res-recruitment";
 import { useEffect, useState } from "react";
-//import { useParams } from "react-router";
+import { useParams } from "react-router";
 
 //더미 포스트 데이터 실제론 api 준비
 const dummyPostData: PostDetail = {
@@ -139,7 +140,8 @@ const dummyCommenList: CommentList = {
 };
 
 export default function RecruitmentDetail() {
-  //const { postId } = useParams();
+  const { postId } = useParams();
+
   const {
     title,
     is_bookmarked: isBookmarked,
@@ -167,6 +169,10 @@ export default function RecruitmentDetail() {
   useEffect(() => {
     setTimeDiff(getTimeDiff(new Date(createdAt)));
   }, [createdAt, setTimeDiff]);
+
+  if (!postId) {
+    return <div>해당 게시물은 삭제되었습니다.</div>;
+  }
 
   return (
     <div className="bg-bg-primary text-text-primary p-2 flex justify-center ">
@@ -286,9 +292,14 @@ export default function RecruitmentDetail() {
         </div>
 
         <div className="flex flex-col items-start w-full max-w-[512px] space-y-1">
-          {dummyCommenList.comments.map((comment) => (
-            <CommentUI comment={comment} key={comment.id} className="w-full" />
-          ))}
+          <CommentInput postId={postId} className="w-full" />
+          {dummyCommenList.comments.length > 0 ? (
+            dummyCommenList.comments.map((comment) => (
+              <CommentUI comment={comment} key={comment.id} className="w-full" />
+            ))
+          ) : (
+            <Text>아직 댓글이 없습니다</Text>
+          )}
         </div>
       </div>
     </div>

--- a/src/pages/recruitment-post/RecruitmentDetail.tsx
+++ b/src/pages/recruitment-post/RecruitmentDetail.tsx
@@ -170,11 +170,16 @@ export default function RecruitmentDetail() {
 
   return (
     <div className="bg-bg-primary text-text-primary p-2 flex justify-center ">
-      <div className="flex flex-col gap-3 items-center lg:flex-row lg:items-start">
-        <div className="flex flex-col max-w-2xl">
-          <div className="flex w-full justify-between items-center">
-            <H1 className="truncate w-full">{title}</H1>
-            <BookmarkButton isBookmarked={isBookmarked} size="sm" userId={userId} />
+      <div className="flex flex-col gap-3 items-center max-w-full min-w-0 ">
+        <div className="flex flex-col max-w-2xl min-w-0">
+          <div className="flex max-w-full min-w-0 justify-between items-center">
+            <H1 className="truncate  min-w-0 flex-1">{title}</H1>
+            <BookmarkButton
+              isBookmarked={isBookmarked}
+              className="shrink-0"
+              size="sm"
+              userId={userId}
+            />
           </div>
 
           <div className="flex justify-between items-center w-full mt-2 mb-3">


### PR DESCRIPTION
## 📌 개요

구인글 상세 페이지 개발

## ✅ 작업 내용

- 구인글 상세 정보 렌더링
- 댓글 정보 렌더링
- 댓글 입력
- 글 주인은 수정 및 마감 가능
- 마감 상태 변경 모달

## TODO
- 실제 api 연결
- 제목 잘림 현상 해결

## 🔍 관련 이슈

Closes #151

## 📸 스크린샷 (선택)
<img width="1666" height="3266" alt="localhost_5173_recruitment-post_1" src="https://github.com/user-attachments/assets/391f7738-aa10-40af-bf19-bde1a6d71ac7" />
