### PR TITLE
#164 useDebounce 훅

### DIFF
--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from "react";
+
+export function useDebounce<T>(value: T, delayMS = 500): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delayMS);
+
+    // cleanup timeout if value or delay changes
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delayMS]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
## 📌 개요

어디서든 범용적으로 사용할 수 있는 useDebounce 훅. 검색 시 주로 사용 예정.

## ✅ 작업 내용

- useDebounce 훅.

## 🔍 관련 이슈

Closes #164

## 사용 예시 코드
+ searchParams를 debounce해서 api 호출
```typescript
  const [searchParams] = useSearchParams();
  const debouncedParams = useDebounce(searchParams);

  useEffect(() => {
    //실제 코드에선 api 호출하는 코드 넣기
    console.log(`Fetch with ${debouncedParams}`);
  }, [debouncedParams]);
```
