### PR TITLE
#166 회원가입 api 연결

### DIFF
--- a/src/constants/api-constants.ts
+++ b/src/constants/api-constants.ts
@@ -1,0 +1,1 @@
+export const API_BASE_URL = "http://13.125.133.127:8000/api/v1";

--- a/src/pages/auth/SignUp.tsx
+++ b/src/pages/auth/SignUp.tsx
@@ -7,6 +7,9 @@ import { Link } from "react-router";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation } from "@tanstack/react-query";
+import axios, { AxiosError } from "axios";
+import { API_BASE_URL } from "@/constants/api-constants";
 
 const SignUpSchema = z
   .object({
@@ -33,9 +36,28 @@ const SignUp = () => {
     reset,
   } = useForm<TSignUpSchema>({ resolver: zodResolver(SignUpSchema) });
 
-  const onSubmit = async () => {
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-    reset();
+  const { mutate } = useMutation({
+    mutationFn: (signUpForm: TSignUpSchema) => {
+      return axios.post(`${API_BASE_URL}/users`, {
+        email: signUpForm.email,
+        password: signUpForm.password,
+        nickname: signUpForm.nickName,
+      });
+    },
+    onSuccess: () => {
+      console.log("success");
+    },
+    onError: (e) => {
+      if (e instanceof AxiosError) {
+        console.error(`Error with code ${e.code} ${e.status}`);
+      } else {
+        console.error("unexpected error");
+      }
+    },
+  });
+
+  const onSubmit = async (form: TSignUpSchema) => {
+    mutate(form);
   };
 
   const handleGoogleSignUp = (): void => {};

--- a/src/pages/auth/SignUp.tsx
+++ b/src/pages/auth/SignUp.tsx
@@ -3,13 +3,15 @@ import Input from "@/components/input/Input";
 import Text from "@/components/text/Text";
 import { FcGoogle } from "react-icons/fc";
 import { FaArrowLeftLong } from "react-icons/fa6";
-import { Link } from "react-router";
+import { Link, useNavigate } from "react-router";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation } from "@tanstack/react-query";
 import axios, { AxiosError } from "axios";
 import { API_BASE_URL } from "@/constants/api-constants";
+import { useState } from "react";
+import InlineSpinner from "@/components/loading/InlineSpinner";
 
 const SignUpSchema = z
   .object({
@@ -32,11 +34,13 @@ const SignUp = () => {
   const {
     register,
     handleSubmit,
-    formState: { errors, isSubmitting },
-    reset,
+    formState: { errors },
   } = useForm<TSignUpSchema>({ resolver: zodResolver(SignUpSchema) });
 
-  const { mutate } = useMutation({
+  const [apiError, setApiError] = useState("");
+  const navigate = useNavigate();
+
+  const { mutate, isPending } = useMutation({
     mutationFn: (signUpForm: TSignUpSchema) => {
       return axios.post(`${API_BASE_URL}/users`, {
         email: signUpForm.email,
@@ -45,13 +49,21 @@ const SignUp = () => {
       });
     },
     onSuccess: () => {
-      console.log("success");
+      setApiError("");
+      navigate("/login");
     },
     onError: (e) => {
       if (e instanceof AxiosError) {
         console.error(`Error with code ${e.code} ${e.status}`);
+        if (e.status === 409) {
+          setApiError("중복된 이메일입니다.");
+        } else if (e.status === 400) {
+          setApiError("올바르지 못한 형식입니다.");
+        } else {
+          setApiError("알 수 없는 서버 에러가 발생했습니다. 잠시후 다시 시도해주세요.");
+        }
       } else {
-        console.error("unexpected error");
+        setApiError("알 수 없는 서버 에러가 발생했습니다. 잠시후 다시 시도해주세요.");
       }
     },
   });
@@ -112,14 +124,19 @@ const SignUp = () => {
               placeholder="비밀번호를 확인해주세요"
               error={errors.confirmPassword?.message}
             />
+            <Text variant="label" className="text-error">
+              {apiError}
+            </Text>
           </div>
           <div className="flex flex-col gap-6">
             <Button
               variant="default"
               className="p-3 bg-primary-thick hover:scale-100 disabled:bg-error"
-              disabled={isSubmitting}
+              disabled={isPending}
             >
-              <Text className="text-base font-semibold text-text-on-dark ">회원가입</Text>
+              <Text className="text-base font-semibold text-text-on-dark ">
+                {isPending ? <InlineSpinner /> : "회원가입"}
+              </Text>
             </Button>
             <Button
               variant="default"


### PR DESCRIPTION
## 📌 개요

회원가입 api 연결

## ✅ 작업 내용

- 회원가입 api 연결
- 서버 에러 발생 시 유저에게 문구 출력
- 중복 이메일 전송 시 유저에게 문구 출력
- 회원가입 성공 시 로그인 페이지로 이동

## 🔍 관련 이슈

Closes #166

## 📸 스크린샷 (선택)

변경사항이 UI에 영향을 주었다면 스크린샷을 포함해주세요.
