### PR TITLE
#170 로그인 api 연결

### DIFF
--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -36,7 +36,8 @@ const LogIn = () => {
     },
 
     onSuccess: (res) => {
-      console.log(res.data.access_token);
+      localStorage.setItem("akabi-token-information", JSON.stringify(res.data));
+      navigate("/");
     },
 
     onError: (e) => {

--- a/src/types/api-res-auth.d.ts
+++ b/src/types/api-res-auth.d.ts
@@ -1,0 +1,5 @@
+export interface TokenInfo {
+  access_token: string;
+  refresh_token: string;
+  token_type: string;
+}


### PR DESCRIPTION
## 📌 개요

 로그인 api 연결

## ✅ 작업 내용

- 로그인 api 연결
- 에러 핸들링
- 성공시 토큰 정보 로컬스토리지에 저장

## TODO
- 토큰 자동으로 header에 넣어주는 함수
- 유저 정보 캐싱 로직
- 자동 refresh 로직

## 🔍 관련 이슈

Closes #170

## 📸 스크린샷 (선택)

변경사항이 UI에 영향을 주었다면 스크린샷을 포함해주세요.
