### PR TITLE
#173 인증 로직

### DIFF
--- a/src/constants/api-constants.ts
+++ b/src/constants/api-constants.ts
@@ -1,1 +1,3 @@
 export const API_BASE_URL = "http://13.125.133.127:8000/api/v1";
+
+export const TOKEN_INFO_KEY = "akabi-token-information";

--- a/src/hooks/api/useUserInfo.ts
+++ b/src/hooks/api/useUserInfo.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query";
+import api from "@/libs/axios";
+import type { MyUserInfo } from "@/types/api-res-profile";
+import type { AxiosResponse } from "axios";
+import { TOKEN_INFO_KEY } from "@/constants/api-constants";
+
+async function fetchUserInfo(): Promise<AxiosResponse<MyUserInfo>> {
+  const res = await api.get<MyUserInfo>("/users/me");
+  return res;
+}
+
+export function useUserInfo() {
+  return useQuery({
+    queryKey: ["user"],
+    queryFn: fetchUserInfo,
+    enabled: !!localStorage.getItem(TOKEN_INFO_KEY),
+    staleTime: 1000 * 60 * 5,
+  });
+}

--- a/src/hooks/api/useUserInfo.ts
+++ b/src/hooks/api/useUserInfo.ts
@@ -2,7 +2,6 @@ import { useQuery } from "@tanstack/react-query";
 import api from "@/libs/axios";
 import type { MyUserInfo } from "@/types/api-res-profile";
 import type { AxiosResponse } from "axios";
-import { TOKEN_INFO_KEY } from "@/constants/api-constants";
 
 async function fetchUserInfo(): Promise<AxiosResponse<MyUserInfo>> {
   const res = await api.get<MyUserInfo>("/users/me");
@@ -10,10 +9,15 @@ async function fetchUserInfo(): Promise<AxiosResponse<MyUserInfo>> {
 }
 
 export function useUserInfo() {
-  return useQuery({
+  const { data: res, status } = useQuery({
     queryKey: ["user"],
     queryFn: fetchUserInfo,
-    enabled: !!localStorage.getItem(TOKEN_INFO_KEY),
     staleTime: 1000 * 60 * 5,
   });
+
+  if (status === "success") {
+    return res.data;
+  } else {
+    return false;
+  }
 }

--- a/src/libs/axios.ts
+++ b/src/libs/axios.ts
@@ -1,0 +1,20 @@
+import { API_BASE_URL, TOKEN_INFO_KEY } from "@/constants/api-constants";
+import type { TokenInfo } from "@/types/api-res-auth";
+import axios from "axios";
+
+const api = axios.create({
+  baseURL: API_BASE_URL,
+});
+
+api.interceptors.request.use((config) => {
+  const tokenStr = localStorage.getItem(TOKEN_INFO_KEY);
+
+  if (tokenStr) {
+    const tokenInfo: TokenInfo = JSON.parse(tokenStr);
+    config.headers.Authorization = `Bearer ${tokenInfo.access_token}`;
+  }
+
+  return config;
+});
+
+export default api;

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -9,7 +9,7 @@ import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation } from "@tanstack/react-query";
 import axios, { AxiosError, type AxiosResponse } from "axios";
-import { API_BASE_URL } from "@/constants/api-constants";
+import { API_BASE_URL, TOKEN_INFO_KEY } from "@/constants/api-constants";
 import type { TokenInfo } from "@/types/api-res-auth";
 import InlineSpinner from "@/components/loading/InlineSpinner";
 import { useState } from "react";
@@ -36,7 +36,7 @@ const LogIn = () => {
     },
 
     onSuccess: (res) => {
-      localStorage.setItem("akabi-token-information", JSON.stringify(res.data));
+      localStorage.setItem(TOKEN_INFO_KEY, JSON.stringify(res.data));
       navigate("/");
     },
 

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -8,11 +8,12 @@ import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation } from "@tanstack/react-query";
-import axios, { AxiosError, type AxiosResponse } from "axios";
-import { API_BASE_URL, TOKEN_INFO_KEY } from "@/constants/api-constants";
+import { AxiosError, type AxiosResponse } from "axios";
+import { TOKEN_INFO_KEY } from "@/constants/api-constants";
 import type { TokenInfo } from "@/types/api-res-auth";
 import InlineSpinner from "@/components/loading/InlineSpinner";
 import { useState } from "react";
+import api from "@/libs/axios";
 
 const logInSchema = z.object({
   email: z.string().email({ message: "유효한 이메일 주소를 입력해주세요" }),
@@ -30,7 +31,7 @@ const LogIn = () => {
       params.append("username", form.email);
       params.append("password", form.password);
 
-      return axios.post(`${API_BASE_URL}/auth/token`, params, {
+      return api.post(`/auth/token`, params, {
         headers: { "Content-Type": "application/x-www-form-urlencoded" },
       });
     },

--- a/src/pages/auth/SignUp.tsx
+++ b/src/pages/auth/SignUp.tsx
@@ -8,10 +8,10 @@ import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation } from "@tanstack/react-query";
-import axios, { AxiosError } from "axios";
-import { API_BASE_URL } from "@/constants/api-constants";
+import { AxiosError } from "axios";
 import { useState } from "react";
 import InlineSpinner from "@/components/loading/InlineSpinner";
+import api from "@/libs/axios";
 
 const SignUpSchema = z
   .object({
@@ -42,7 +42,7 @@ const SignUp = () => {
 
   const { mutate, isPending } = useMutation({
     mutationFn: (signUpForm: TSignUpSchema) => {
-      return axios.post(`${API_BASE_URL}/users`, {
+      return api.post(`/users`, {
         email: signUpForm.email,
         password: signUpForm.password,
         nickname: signUpForm.nickName,


### PR DESCRIPTION
## 📌 개요

인증 로직 구현

## ✅ 작업 내용

### 인증 로직 개요
<img width="3132" height="1424" alt="image" src="https://github.com/user-attachments/assets/86bafde4-e543-4b3a-9ee2-8c17aaa35623" />
(local storage와 tanstack query도 클라이언트의 일부지만 직관성을 위해 분리해서 표현)

### api 커스텀 인스턴스
+ api 커스텀 인스턴스를 만들어 axios 대신 사용하면 된다.
+ 자동으로 base url과 토큰 값을 넣어준다.
+ 사용 예시
```typescript
  const { mutate, isPending } = useMutation({
    mutationFn: (signUpForm: TSignUpSchema) => {
      return api.post(`/users`, {
        email: signUpForm.email,
        password: signUpForm.password,
        nickname: signUpForm.nickName,
      });
    },
// other codes
```

### 유저 정보 캐싱
+ tanstack query를 사용한 유저 정보 캐싱
+ 같은 쿼리 키(["user"] 사용하지 않도록 주의!!
+ 필요한 곳에서 useUserInfo 훅을 사용하면 된다.
+ 로그인 상태 시 MyUserInfo 반환
+ 비로그인 상태 및 토큰 만료 시 false 반환

## TODO
- 자동 토큰 리프레시 (api 아직 준비 안 됨)
- 토큰 값 쿠키로 받기 (백엔드에서 해줘야 함)
- 로그아웃 로직에서 캐시 삭제 로직이 필수로 있어야한다.

## 🔍 관련 이슈

Closes #173

## 📸 스크린샷 (선택)

변경사항이 UI에 영향을 주었다면 스크린샷을 포함해주세요.
