### PR TITLE
#183 구인글 카드 수정

### DIFF
--- a/src/components/RecruitmentCard.tsx
+++ b/src/components/RecruitmentCard.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router";
 import H3 from "@/components/text/H3";
 import Text from "@/components/text/Text";
 import Badge from "@/components/Badge";
-import { getTimeDiff } from "@/libs/utils";
+import { cn, getTimeDiff } from "@/libs/utils";
 import BookmarkButton from "@/components/BookmarkBtn";
 import EyeIcon from "@/components/icons/EyeIcon";
 import CommentIcon from "@/components/icons/CommentIcon";
@@ -12,9 +12,10 @@ import type { Post } from "@/types/api-res-recruitment";
 
 interface RecruitmentCardProps {
   postData: Post;
+  className?: string;
 }
 
-export default function RecruitmentCard({ postData }: RecruitmentCardProps) {
+export default function RecruitmentCard({ postData, className = "" }: RecruitmentCardProps) {
   const {
     id,
     title,
@@ -41,7 +42,10 @@ export default function RecruitmentCard({ postData }: RecruitmentCardProps) {
   return (
     <Link
       to={`/recruitment-post/${id}`}
-      className="flex flex-col items-start p-5 bg-bg-secondary text-text-primary transition-shadow rounded-xl w-full max-w-96 hover:shadow-lg hover:shadow-primary-thick"
+      className={cn(
+        "flex flex-col items-start p-5 bg-bg-secondary text-text-primary transition-shadow rounded-xl w-full max-w-96 hover:shadow-lg hover:shadow-primary-thick",
+        className
+      )}
     >
       <div className="flex w-full justify-between items-center">
         <H3 className="truncate w-full">{title}</H3>

--- a/src/components/RecruitmentCard.tsx
+++ b/src/components/RecruitmentCard.tsx
@@ -40,7 +40,7 @@ export default function RecruitmentCard({ postData }: RecruitmentCardProps) {
 
   return (
     <Link
-      to="#"
+      to={`/recruitment-post/${id}`}
       className="flex flex-col items-start p-5 bg-bg-secondary text-text-primary transition-shadow rounded-xl w-full max-w-96 hover:shadow-lg hover:shadow-primary-thick"
     >
       <div className="flex w-full justify-between items-center">

--- a/src/components/RecruitmentCard.tsx
+++ b/src/components/RecruitmentCard.tsx
@@ -69,7 +69,7 @@ export default function RecruitmentCard({ postData }: RecruitmentCardProps) {
 
       <div className="flex flex-col justify-between w-full sm:flex-row">
         <div className="flex flex-col space-y-0.5 flex-1">
-          {positions ? (
+          {positions && positions.length > 0 ? (
             <div className="flex items-center space-x-1">
               <Text variant="mainText">포지션</Text>
               {positions.slice(0, 3).map(({ position_name: positionName }, i) => (
@@ -80,7 +80,7 @@ export default function RecruitmentCard({ postData }: RecruitmentCardProps) {
             </div>
           ) : null}
 
-          {regions ? (
+          {regions && regions.length > 0 ? (
             <div className="flex items-center space-x-1">
               <Text variant="mainText">지역</Text>
               {regions.slice(0, 3).map((region, i) => (
@@ -91,7 +91,7 @@ export default function RecruitmentCard({ postData }: RecruitmentCardProps) {
             </div>
           ) : null}
 
-          {genres ? (
+          {genres && genres.length > 0 ? (
             <div className="flex items-center space-x-1">
               <Text variant="mainText">선호장르</Text>
               {genres.slice(0, 3).map((genre, i) => (

--- a/src/components/RecruitmentCard.tsx
+++ b/src/components/RecruitmentCard.tsx
@@ -71,7 +71,7 @@ export default function RecruitmentCard({ postData, className = "" }: Recruitmen
         </div>
       </div>
 
-      <div className="flex flex-col justify-between w-full sm:flex-row">
+      <div className="flex flex-col justify-between w-full flex-1 sm:flex-row">
         <div className="flex flex-col space-y-0.5 flex-1">
           {positions && positions.length > 0 ? (
             <div className="flex items-center space-x-1">

--- a/src/components/RecruitmentCard.tsx
+++ b/src/components/RecruitmentCard.tsx
@@ -73,7 +73,7 @@ export default function RecruitmentCard({ postData }: RecruitmentCardProps) {
             <div className="flex items-center space-x-1">
               <Text variant="mainText">포지션</Text>
               {positions.slice(0, 3).map(({ position_name: positionName }, i) => (
-                <Badge size="sm" key={i}>
+                <Badge size="sm" className="text-text-on-dark" key={i}>
                   {positionName}
                 </Badge>
               ))}
@@ -84,7 +84,7 @@ export default function RecruitmentCard({ postData }: RecruitmentCardProps) {
             <div className="flex items-center space-x-1">
               <Text variant="mainText">지역</Text>
               {regions.slice(0, 3).map((region, i) => (
-                <Badge size="sm" key={i}>
+                <Badge size="sm" className="text-text-on-dark" key={i}>
                   {region.name}
                 </Badge>
               ))}
@@ -95,7 +95,7 @@ export default function RecruitmentCard({ postData }: RecruitmentCardProps) {
             <div className="flex items-center space-x-1">
               <Text variant="mainText">선호장르</Text>
               {genres.slice(0, 3).map((genre, i) => (
-                <Badge size="sm" key={i}>
+                <Badge size="sm" className="text-text-on-dark" key={i}>
                   {genre.name}
                 </Badge>
               ))}
@@ -105,7 +105,9 @@ export default function RecruitmentCard({ postData }: RecruitmentCardProps) {
           {orientation ? (
             <div className="flex items-center space-x-1">
               <Text variant="mainText">지향</Text>
-              <Badge size="sm">{orientation.name}</Badge>
+              <Badge size="sm" className="text-text-on-dark">
+                {orientation.name}
+              </Badge>
             </div>
           ) : null}
         </div>


### PR DESCRIPTION
## 📌 개요

구인글 카드 수정

## ✅ 작업 내용

- 뱃지 내 텍스트 색상 화이트로 변경
- 구인글 카드 속성 조건부 렌더링 조건 변경
  - 길이까지 확인
- 구인글 상세로 가는 링크 주소 추가
- className prop 추가
- 레이아웃 일부 수정 

## 🔍 관련 이슈

Closes #183

## 📸 스크린샷 (선택)
<img width="794" height="525" alt="Screenshot 2025-08-22 at 11 41 08 AM" src="https://github.com/user-attachments/assets/b0ebf397-7dc6-4ed2-8522-f28ed86c1bb3" />

