### PR TITLE
#182 구인글 리스트 api 연결

### DIFF
--- a/src/components/Filter.tsx
+++ b/src/components/Filter.tsx
@@ -9,7 +9,6 @@ import { useEffect, useState } from "react";
 import type { MasterData } from "@/types/api-res-common";
 import { useQuery } from "@tanstack/react-query";
 import api from "@/libs/axios";
-import type { AxiosResponse } from "axios";
 import InlineSpinner from "@/components/loading/InlineSpinner";
 import H3 from "@/components/text/H3";
 
@@ -30,10 +29,11 @@ export default function Filter({
   className = "",
   isLogin = false,
 }: FilterProps) {
-  const { isPending, data } = useQuery<AxiosResponse<MasterData>>({
+  const { isPending, data } = useQuery<MasterData>({
     queryKey: ["master-data"],
-    queryFn: () => {
-      return api.get("/common/master-data");
+    queryFn: async () => {
+      const res = await api.get("/common/master-data");
+      return res.data;
     },
   });
 
@@ -116,16 +116,16 @@ export default function Filter({
             <FilterSection queryKey="bookmarks" title={"북마크"} data={bookmarks} mode="single" />
           ) : null}
 
-          <FilterSection queryKey="region_ids" title={"지역"} data={data.data.regions} />
-          <FilterSection queryKey="genre_ids" title={"선호 장르"} data={data.data.genres} />
-          <FilterSection queryKey="position_ids" title={"포지션"} data={data.data.positions} />
+          <FilterSection queryKey="region_ids" title={"지역"} data={data.regions} />
+          <FilterSection queryKey="genre_ids" title={"선호 장르"} data={data.genres} />
+          <FilterSection queryKey="position_ids" title={"포지션"} data={data.positions} />
           <FilterSection
             queryKey="experienced_level"
             title={filterType === "recruitmentPostFilter" ? "요구 경력" : "경력"}
-            data={data.data.experience_levels}
+            data={data.experience_levels}
           />
           {!isProfile && (
-            <FilterSection queryKey="orientation" title="지향" data={data.data.orientations} />
+            <FilterSection queryKey="orientation" title="지향" data={data.orientations} />
           )}
         </div>
       ) : (

--- a/src/components/Filter.tsx
+++ b/src/components/Filter.tsx
@@ -116,16 +116,16 @@ export default function Filter({
             <FilterSection queryKey="bookmarks" title={"북마크"} data={bookmarks} mode="single" />
           ) : null}
 
-          <FilterSection queryKey="region_ids" title={"지역"} data={data.data.genres} />
+          <FilterSection queryKey="region_ids" title={"지역"} data={data.data.regions} />
           <FilterSection queryKey="genre_ids" title={"선호 장르"} data={data.data.genres} />
-          <FilterSection queryKey="positions_id" title={"포지션"} data={data.data.positions} />
+          <FilterSection queryKey="position_ids" title={"포지션"} data={data.data.positions} />
           <FilterSection
-            queryKey="experience_level_ids"
+            queryKey="experienced_level"
             title={filterType === "recruitmentPostFilter" ? "요구 경력" : "경력"}
             data={data.data.experience_levels}
           />
           {!isProfile && (
-            <FilterSection queryKey="orientation_ids" title="지향" data={data.data.orientations} />
+            <FilterSection queryKey="orientation" title="지향" data={data.data.orientations} />
           )}
         </div>
       ) : (

--- a/src/components/Filter.tsx
+++ b/src/components/Filter.tsx
@@ -7,67 +7,11 @@ import useSelectQuery from "@/hooks/useSelectQuery";
 import useWindowWidth from "@/hooks/useWindowWidth";
 import { useEffect, useState } from "react";
 import type { MasterData } from "@/types/api-res-common";
-
-//마스터 데이터 실제론 api로 받기
-const MASTER_DATA: MasterData = {
-  regions: [
-    { id: "1", name: "서울 서부" },
-    { id: "2", name: "서울 동부" },
-    { id: "3", name: "서울 남부" },
-    { id: "4", name: "서울 북부" },
-    { id: "5", name: "인천" },
-    { id: "6", name: "부산" },
-    { id: "7", name: "대구" },
-    { id: "8", name: "광주" },
-    { id: "9", name: "대전" },
-    { id: "10", name: "울산" },
-    { id: "11", name: "제주" },
-    { id: "12", name: "경기" },
-    { id: "13", name: "강원" },
-    { id: "14", name: "충북" },
-    { id: "15", name: "충남" },
-    { id: "16", name: "경북" },
-    { id: "17", name: "경남" },
-    { id: "18", name: "전북" },
-    { id: "19", name: "전남" },
-  ],
-  positions: [
-    { id: "p1", name: "보컬" },
-    { id: "p2", name: "일렉 기타" },
-    { id: "p3", name: "어쿠스틱 기타" },
-    { id: "p4", name: "베이스" },
-    { id: "p5", name: "드럼" },
-    { id: "p6", name: "키보드" },
-    { id: "p7", name: "그 외" },
-  ],
-  genres: [
-    { id: "g1", name: "인디락" },
-    { id: "g2", name: "K-pop" },
-    { id: "g3", name: "J-pop" },
-    { id: "g4", name: "메탈" },
-    { id: "g5", name: "하드락" },
-    { id: "g6", name: "재즈" },
-    { id: "g7", name: "그 외" },
-  ],
-  experience_levels: [
-    { id: "e1", name: "취미 1년 이하" },
-    { id: "e2", name: "취미 3년 이하" },
-    { id: "e3", name: "취미 5년 이하" },
-    { id: "e4", name: "취미 5년 이상" },
-    { id: "e5", name: "전공" },
-    { id: "e6", name: "프로" },
-  ],
-  orientations: [
-    { id: "o1", name: "취미" },
-    { id: "o2", name: "프로" },
-    { id: "o3", name: "프로 지향" },
-  ],
-  recruitment_types: [
-    { id: "r1", name: "고정 밴드" },
-    { id: "r2", name: "프로젝트 밴드" },
-  ],
-  recruiting_post_types: [],
-};
+import { useQuery } from "@tanstack/react-query";
+import api from "@/libs/axios";
+import type { AxiosResponse } from "axios";
+import InlineSpinner from "@/components/loading/InlineSpinner";
+import H3 from "@/components/text/H3";
 
 const NICKNAME_QUERY_KEY = "nickname";
 const SEARCH_QUERY_KEY = "search_query";
@@ -86,14 +30,12 @@ export default function Filter({
   className = "",
   isLogin = false,
 }: FilterProps) {
-  //마스터 데이터 실제론 api로 받기
-  const {
-    regions,
-    positions,
-    genres,
-    experience_levels: experienceLevels,
-    orientations,
-  } = MASTER_DATA;
+  const { isPending, data } = useQuery<AxiosResponse<MasterData>>({
+    queryKey: ["master-data"],
+    queryFn: () => {
+      return api.get("/common/master-data");
+    },
+  });
 
   const sortBys = [
     { id: "latest", name: "최신순" },
@@ -161,28 +103,34 @@ export default function Filter({
           onClick={handleInitializeClick}
         />
       </div>
-      <div className={cn("flex flex-col space-y-2", isVisible ? "visible" : "hidden")}>
-        <FilterSection queryKey="sort_by" title="정렬" data={sortBys} mode="single" />
-        {isProfile ? (
-          <FilterSection queryKey="order_by" title="순서" data={orderBys} mode="single" />
-        ) : null}
+      {isPending ? (
+        <InlineSpinner />
+      ) : data ? (
+        <div className={cn("flex flex-col space-y-2", isVisible ? "visible" : "hidden")}>
+          <FilterSection queryKey="sort_by" title="정렬" data={sortBys} mode="single" />
+          {isProfile ? (
+            <FilterSection queryKey="order_by" title="순서" data={orderBys} mode="single" />
+          ) : null}
 
-        {isLogin ? (
-          <FilterSection queryKey="bookmarks" title={"북마크"} data={bookmarks} mode="single" />
-        ) : null}
+          {isLogin ? (
+            <FilterSection queryKey="bookmarks" title={"북마크"} data={bookmarks} mode="single" />
+          ) : null}
 
-        <FilterSection queryKey="region_ids" title={"지역"} data={regions} />
-        <FilterSection queryKey="genre_ids" title={"선호 장르"} data={genres} />
-        <FilterSection queryKey="positions_id" title={"포지션"} data={positions} />
-        <FilterSection
-          queryKey="experience_level_ids"
-          title={filterType === "recruitmentPostFilter" ? "요구 경력" : "경력"}
-          data={experienceLevels}
-        />
-        {!isProfile && (
-          <FilterSection queryKey="orientation_ids" title="지향" data={orientations} />
-        )}
-      </div>
+          <FilterSection queryKey="region_ids" title={"지역"} data={data.data.genres} />
+          <FilterSection queryKey="genre_ids" title={"선호 장르"} data={data.data.genres} />
+          <FilterSection queryKey="positions_id" title={"포지션"} data={data.data.positions} />
+          <FilterSection
+            queryKey="experience_level_ids"
+            title={filterType === "recruitmentPostFilter" ? "요구 경력" : "경력"}
+            data={data.data.experience_levels}
+          />
+          {!isProfile && (
+            <FilterSection queryKey="orientation_ids" title="지향" data={data.data.orientations} />
+          )}
+        </div>
+      ) : (
+        <H3 className="text-text-primary">데이터 로딩에 실패했습니다. 잠시후 다시 시도해주세요.</H3>
+      )}
     </div>
   );
 }

--- a/src/components/RecruitmentCard.tsx
+++ b/src/components/RecruitmentCard.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router";
 import H3 from "@/components/text/H3";
 import Text from "@/components/text/Text";
 import Badge from "@/components/Badge";
-import { getTimeDiff } from "@/libs/utils";
+import { cn, getTimeDiff } from "@/libs/utils";
 import BookmarkButton from "@/components/BookmarkBtn";
 import EyeIcon from "@/components/icons/EyeIcon";
 import CommentIcon from "@/components/icons/CommentIcon";
@@ -12,9 +12,10 @@ import type { Post } from "@/types/api-res-recruitment";
 
 interface RecruitmentCardProps {
   postData: Post;
+  className?: string;
 }
 
-export default function RecruitmentCard({ postData }: RecruitmentCardProps) {
+export default function RecruitmentCard({ postData, className = "" }: RecruitmentCardProps) {
   const {
     id,
     title,
@@ -41,7 +42,10 @@ export default function RecruitmentCard({ postData }: RecruitmentCardProps) {
   return (
     <Link
       to={`/recruitment-post/${id}`}
-      className="flex flex-col items-start p-5 bg-bg-secondary text-text-primary transition-shadow rounded-xl w-full max-w-96 hover:shadow-lg hover:shadow-primary-thick"
+      className={cn(
+        "flex flex-col items-start p-5 bg-bg-secondary text-text-primary transition-shadow rounded-xl w-full max-w-96 hover:shadow-lg hover:shadow-primary-thick",
+        className
+      )}
     >
       <div className="flex w-full justify-between items-center">
         <H3 className="truncate w-full">{title}</H3>

--- a/src/components/RecruitmentCard.tsx
+++ b/src/components/RecruitmentCard.tsx
@@ -40,7 +40,7 @@ export default function RecruitmentCard({ postData }: RecruitmentCardProps) {
 
   return (
     <Link
-      to="#"
+      to={`/recruitment-post/${id}`}
       className="flex flex-col items-start p-5 bg-bg-secondary text-text-primary transition-shadow rounded-xl w-full max-w-96 hover:shadow-lg hover:shadow-primary-thick"
     >
       <div className="flex w-full justify-between items-center">

--- a/src/components/RecruitmentCard.tsx
+++ b/src/components/RecruitmentCard.tsx
@@ -69,7 +69,7 @@ export default function RecruitmentCard({ postData }: RecruitmentCardProps) {
 
       <div className="flex flex-col justify-between w-full sm:flex-row">
         <div className="flex flex-col space-y-0.5 flex-1">
-          {positions ? (
+          {positions && positions.length > 0 ? (
             <div className="flex items-center space-x-1">
               <Text variant="mainText">포지션</Text>
               {positions.slice(0, 3).map(({ position_name: positionName }, i) => (
@@ -80,7 +80,7 @@ export default function RecruitmentCard({ postData }: RecruitmentCardProps) {
             </div>
           ) : null}
 
-          {regions ? (
+          {regions && regions.length > 0 ? (
             <div className="flex items-center space-x-1">
               <Text variant="mainText">지역</Text>
               {regions.slice(0, 3).map((region, i) => (
@@ -91,7 +91,7 @@ export default function RecruitmentCard({ postData }: RecruitmentCardProps) {
             </div>
           ) : null}
 
-          {genres ? (
+          {genres && genres.length > 0 ? (
             <div className="flex items-center space-x-1">
               <Text variant="mainText">선호장르</Text>
               {genres.slice(0, 3).map((genre, i) => (

--- a/src/components/RecruitmentCard.tsx
+++ b/src/components/RecruitmentCard.tsx
@@ -71,7 +71,7 @@ export default function RecruitmentCard({ postData, className = "" }: Recruitmen
         </div>
       </div>
 
-      <div className="flex flex-col justify-between w-full sm:flex-row">
+      <div className="flex flex-col justify-between w-full flex-1 sm:flex-row">
         <div className="flex flex-col space-y-0.5 flex-1">
           {positions && positions.length > 0 ? (
             <div className="flex items-center space-x-1">

--- a/src/components/RecruitmentCard.tsx
+++ b/src/components/RecruitmentCard.tsx
@@ -73,7 +73,7 @@ export default function RecruitmentCard({ postData }: RecruitmentCardProps) {
             <div className="flex items-center space-x-1">
               <Text variant="mainText">포지션</Text>
               {positions.slice(0, 3).map(({ position_name: positionName }, i) => (
-                <Badge size="sm" key={i}>
+                <Badge size="sm" className="text-text-on-dark" key={i}>
                   {positionName}
                 </Badge>
               ))}
@@ -84,7 +84,7 @@ export default function RecruitmentCard({ postData }: RecruitmentCardProps) {
             <div className="flex items-center space-x-1">
               <Text variant="mainText">지역</Text>
               {regions.slice(0, 3).map((region, i) => (
-                <Badge size="sm" key={i}>
+                <Badge size="sm" className="text-text-on-dark" key={i}>
                   {region.name}
                 </Badge>
               ))}
@@ -95,7 +95,7 @@ export default function RecruitmentCard({ postData }: RecruitmentCardProps) {
             <div className="flex items-center space-x-1">
               <Text variant="mainText">선호장르</Text>
               {genres.slice(0, 3).map((genre, i) => (
-                <Badge size="sm" key={i}>
+                <Badge size="sm" className="text-text-on-dark" key={i}>
                   {genre.name}
                 </Badge>
               ))}
@@ -105,7 +105,9 @@ export default function RecruitmentCard({ postData }: RecruitmentCardProps) {
           {orientation ? (
             <div className="flex items-center space-x-1">
               <Text variant="mainText">지향</Text>
-              <Badge size="sm">{orientation.name}</Badge>
+              <Badge size="sm" className="text-text-on-dark">
+                {orientation.name}
+              </Badge>
             </div>
           ) : null}
         </div>

--- a/src/pages/recruitment-post/RecruitmentList.tsx
+++ b/src/pages/recruitment-post/RecruitmentList.tsx
@@ -2,6 +2,7 @@ import Filter from "@/components/Filter";
 import LoadingOverlay from "@/components/loading/LoadingOverlay";
 import RecruitmentCard from "@/components/RecruitmentCard";
 import H1 from "@/components/text/H1";
+import { useUserInfo } from "@/hooks/api/useUserInfo";
 import api from "@/libs/axios";
 import type { PostList } from "@/types/api-res-recruitment";
 import { useQuery } from "@tanstack/react-query";
@@ -15,15 +16,17 @@ export default function RecruitmentList() {
     },
   });
 
+  const user = useUserInfo();
+
   return (
-    <div className="p-4 gap-2 flex flex-col sm:flex-row bg-bg-primary text-text-primary">
-      <Filter filterType="recruitmentPostFilter" />
+    <div className="p-4 gap-2 flex flex-col items-start sm:flex-row bg-bg-primary text-text-primary">
+      <Filter filterType="recruitmentPostFilter" isLogin={!!user} />
       {isPending ? (
         <LoadingOverlay />
       ) : data ? (
         <div className="flex flex-wrap gap-2 w-full justify-start items-center">
           {data.data.posts.map((post) => (
-            <RecruitmentCard postData={post} key={post.id} />
+            <RecruitmentCard postData={post} key={post.id} className="h-64" />
           ))}
         </div>
       ) : (

--- a/src/pages/recruitment-post/RecruitmentList.tsx
+++ b/src/pages/recruitment-post/RecruitmentList.tsx
@@ -3,18 +3,29 @@ import LoadingOverlay from "@/components/loading/LoadingOverlay";
 import RecruitmentCard from "@/components/RecruitmentCard";
 import H1 from "@/components/text/H1";
 import { useUserInfo } from "@/hooks/api/useUserInfo";
+import { useDebounce } from "@/hooks/useDebounce";
 import api from "@/libs/axios";
 import type { PostList } from "@/types/api-res-recruitment";
 import { useQuery } from "@tanstack/react-query";
-import type { AxiosResponse } from "axios";
+import { useEffect } from "react";
+import { useSearchParams } from "react-router";
 
 export default function RecruitmentList() {
-  const { data, isPending } = useQuery<AxiosResponse<PostList>>({
-    queryKey: ["recruiment-list"],
-    queryFn: () => {
-      return api.get("/recruiting");
+  const [searchParams] = useSearchParams();
+  const debouncedSearchParams = useDebounce(searchParams);
+
+  const { data, isPending, refetch } = useQuery<PostList>({
+    queryKey: ["recruiment-list", debouncedSearchParams.toString()],
+    queryFn: async () => {
+      const res = await api.get("/recruiting", { params: debouncedSearchParams });
+      return res.data;
     },
   });
+
+  useEffect(() => {
+    console.log(debouncedSearchParams.toString());
+    refetch();
+  }, [debouncedSearchParams, refetch]);
 
   const user = useUserInfo();
 
@@ -25,7 +36,7 @@ export default function RecruitmentList() {
         <LoadingOverlay />
       ) : data ? (
         <div className="flex flex-wrap gap-2 w-full justify-start items-center">
-          {data.data.posts.map((post) => (
+          {data.posts.map((post) => (
             <RecruitmentCard postData={post} key={post.id} className="h-64" />
           ))}
         </div>

--- a/src/pages/recruitment-post/RecruitmentList.tsx
+++ b/src/pages/recruitment-post/RecruitmentList.tsx
@@ -1,70 +1,34 @@
 import Filter from "@/components/Filter";
-import type { CommentList } from "@/types/api-res-comment";
-import CommentUI from "@/components/commentUI/CommentUI";
-
-//실제론 api로 호출
-const DUMMY_COMMENT_LIST: CommentList = {
-  next_cursor: "cursor_12345",
-  comments: [
-    {
-      id: "comment_1",
-      content: "첫 번째 댓글입니다.",
-      created_at: "2025-08-12T10:30:00Z",
-      post: {
-        id: "post_1",
-        title: "첫 번째 게시글 제목",
-      },
-      children: [
-        {
-          id: "comment_1_1",
-          content: "첫 번째 댓글의 대댓글입니다.",
-          created_at: "2025-08-12T11:00:00Z",
-          post: {
-            id: "post_1",
-            title: "첫 번째 게시글 제목",
-          },
-          children: [],
-          is_owner: false,
-          author: {
-            user_id: "user_002",
-            nickname: "김한주",
-          },
-        },
-      ],
-      is_owner: true,
-      author: {
-        user_id: "user_001",
-        nickname: "유다빈",
-      },
-    },
-    {
-      id: "comment_2",
-      content: "두 번째 댓글입니다.",
-      created_at: "2025-08-12T12:15:00Z",
-      post: {
-        id: "post_2",
-        title: "두 번째 게시글 제목",
-      },
-      children: [],
-      is_owner: false,
-      author: {
-        user_id: "user_003",
-        nickname: "최웅희",
-      },
-    },
-  ],
-};
+import LoadingOverlay from "@/components/loading/LoadingOverlay";
+import RecruitmentCard from "@/components/RecruitmentCard";
+import H1 from "@/components/text/H1";
+import api from "@/libs/axios";
+import type { PostList } from "@/types/api-res-recruitment";
+import { useQuery } from "@tanstack/react-query";
+import type { AxiosResponse } from "axios";
 
 export default function RecruitmentList() {
+  const { data, isPending } = useQuery<AxiosResponse<PostList>>({
+    queryKey: ["recruiment-list"],
+    queryFn: () => {
+      return api.get("/recruiting");
+    },
+  });
+
   return (
-    <div className="p-4 gap-2 flex flex-col ">
+    <div className="p-4 gap-2 flex flex-col sm:flex-row bg-bg-primary text-text-primary">
       <Filter filterType="recruitmentPostFilter" />
-      RecruitmentList
-      <div className="flex flex-col items-start max-w-sm w-full space-y-0.5">
-        {DUMMY_COMMENT_LIST.comments.map((comment) => (
-          <CommentUI comment={comment} key={comment.id} className="w-full" />
-        ))}
-      </div>
+      {isPending ? (
+        <LoadingOverlay />
+      ) : data ? (
+        <div className="flex flex-wrap gap-2 w-full justify-start items-center">
+          {data.data.posts.map((post) => (
+            <RecruitmentCard postData={post} key={post.id} />
+          ))}
+        </div>
+      ) : (
+        <H1>데이터를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.</H1>
+      )}
     </div>
   );
 }

--- a/src/pages/recruitment-post/RecruitmentList.tsx
+++ b/src/pages/recruitment-post/RecruitmentList.tsx
@@ -7,7 +7,7 @@ import { useDebounce } from "@/hooks/useDebounce";
 import api from "@/libs/axios";
 import type { PostList } from "@/types/api-res-recruitment";
 import { useQuery } from "@tanstack/react-query";
-import { useEffect } from "react";
+import { useEffect, type JSX } from "react";
 import { useSearchParams } from "react-router";
 
 export default function RecruitmentList() {
@@ -30,19 +30,32 @@ export default function RecruitmentList() {
   const user = useUserInfo();
 
   return (
-    <div className="p-4 gap-2 flex flex-col items-start sm:flex-row bg-bg-primary text-text-primary">
+    <div className="p-4 gap-2 flex flex-col items-center justify-start sm:items-start sm:justify-start sm:flex-row bg-bg-primary text-text-primary min-h-screen">
       <Filter filterType="recruitmentPostFilter" isLogin={!!user} />
-      {isPending ? (
-        <LoadingOverlay />
-      ) : data ? (
-        <div className="flex flex-wrap gap-2 w-full justify-start items-center">
-          {data.posts.map((post) => (
-            <RecruitmentCard postData={post} key={post.id} className="h-64" />
-          ))}
-        </div>
-      ) : (
-        <H1>데이터를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.</H1>
-      )}
+
+      {(() => {
+        let content: JSX.Element;
+
+        if (isPending) {
+          content = <LoadingOverlay />;
+        } else if (data) {
+          if (data.posts.length > 0) {
+            content = (
+              <div className="flex flex-wrap gap-2 w-full justify-center items-center">
+                {data.posts.map((post) => (
+                  <RecruitmentCard postData={post} key={post.id} className="h-64" />
+                ))}
+              </div>
+            );
+          } else {
+            content = <H1>조건에 맞는 글이 없습니다.</H1>;
+          }
+        } else {
+          content = <H1>데이터를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.</H1>;
+        }
+
+        return content;
+      })()}
     </div>
   );
 }


### PR DESCRIPTION
## 📌 개요
구인글 리스트 api 연결

## ✅ 작업 내용

- 구인글 리스트 api 연결
- 구인글 query parameter 연결
- 필터 마스터 데이터 api 연결
- 필터 일부 쿼리키 api에 맞게 수정

## TODO
- 쿼리파라미터 복수선택 에러 해결(백엔드 수정 필요)
- 페이지네이션 및 무한스크롤
#188

## 🔍 관련 이슈

Closes #182

## 📸 스크린샷 (선택)

<img width="1204" height="683" alt="Screenshot 2025-08-22 at 2 12 47 PM" src="https://github.com/user-attachments/assets/884ec035-13b4-4e96-b836-f76547e1e2b9" />

<img width="1202" height="662" alt="Screenshot 2025-08-22 at 2 13 07 PM" src="https://github.com/user-attachments/assets/04569a2b-8e15-426b-9609-ad8de9031f7c" />

