### PR TITLE
#205 로그인 로직 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+
+localhost.pem
+localhost-key.pem

--- a/src/constants/api-constants.ts
+++ b/src/constants/api-constants.ts
@@ -1,3 +1,3 @@
-export const API_BASE_URL = "http://13.125.133.127:8000/api/v1";
+export const API_BASE_URL = "https://akabi.site/api/v1";
 
 export const TOKEN_INFO_KEY = "akabi-token-information";

--- a/src/libs/axios.ts
+++ b/src/libs/axios.ts
@@ -1,15 +1,84 @@
 import { API_BASE_URL, TOKEN_INFO_KEY } from "@/constants/api-constants";
+import type { TokenInfo } from "@/types/api-res-auth";
 import axios from "axios";
+import { jwtDecode } from "jwt-decode";
+
+type JwtPayload = { exp?: number };
 
 const api = axios.create({
   baseURL: API_BASE_URL,
+  withCredentials: true,
 });
 
-api.interceptors.request.use((config) => {
+// ===== 토큰 유틸 =====
+function getAccessToken(): string | null {
   const accessToken = localStorage.getItem(TOKEN_INFO_KEY);
+  return accessToken;
+}
+function setAccessToken(accessToken: string) {
+  localStorage.setItem(TOKEN_INFO_KEY, accessToken);
+}
 
-  if (accessToken) {
-    config.headers.Authorization = `Bearer ${accessToken}`;
+function willExpireSoon(accessToken: string, skewSecond = 60): boolean {
+  try {
+    const { exp: expireSecond } = jwtDecode<JwtPayload>(accessToken);
+    if (!expireSecond) return true; // exp가 없다면 안전하게 "곧 만료" 취급 -> 사전 refresh
+    const currentSecond = Math.floor(Date.now() / 1000);
+    return expireSecond - currentSecond <= skewSecond; // 60초 이내면 갱신
+  } catch {
+    return true; // 디코드 실패 시도 "만료" 취급
+  }
+}
+
+// ===== refresh 중복 방지 =====
+let refreshPromise: Promise<string> | null = null;
+
+async function ensureFreshAccessToken(): Promise<string | null> {
+  const accessToken = getAccessToken();
+  if (!accessToken) return null;
+
+  // 만료 임박하지 않다면 그대로 사용
+  if (!willExpireSoon(accessToken)) return accessToken;
+
+  // 이미 다른 요청이 refresh 중이면 그걸 기다림
+  if (refreshPromise) return refreshPromise;
+
+  // 새로 refresh 시작
+  refreshPromise = (async () => {
+    try {
+      // 주의: 여기서는 전역 axios(기본 인스턴스) 사용하여 인터셉터 루프 방지
+      const { data } = await axios.post<TokenInfo>(
+        `${API_BASE_URL}/auth/refresh`,
+        {},
+        { withCredentials: true }
+      );
+
+      setAccessToken(data.access_token);
+      return data.access_token;
+    } catch (e) {
+      // refresh 실패 시 로그인 상태 정리
+      localStorage.removeItem(TOKEN_INFO_KEY);
+      // 필요하면 라우팅
+      // window.location.href = "/login";
+      throw e;
+    } finally {
+      refreshPromise = null;
+    }
+  })();
+
+  return refreshPromise;
+}
+
+// ===== 요청 인터셉터 =====
+api.interceptors.request.use(async (config) => {
+  const accessToken = getAccessToken();
+  if (!accessToken) return config;
+
+  const refreshedAccessToken = await ensureFreshAccessToken().catch(() => null);
+  const finalToken = refreshedAccessToken ?? accessToken;
+
+  if (finalToken) {
+    config.headers.Authorization = `Bearer ${finalToken}`;
   }
 
   return config;

--- a/src/libs/axios.ts
+++ b/src/libs/axios.ts
@@ -22,6 +22,7 @@ function setAccessToken(accessToken: string) {
 function willExpireSoon(accessToken: string, skewSecond = 60): boolean {
   try {
     const { exp: expireSecond } = jwtDecode<JwtPayload>(accessToken);
+
     if (!expireSecond) return true; // exp가 없다면 안전하게 "곧 만료" 취급 -> 사전 refresh
     const currentSecond = Math.floor(Date.now() / 1000);
     return expireSecond - currentSecond <= skewSecond; // 60초 이내면 갱신
@@ -48,7 +49,7 @@ async function ensureFreshAccessToken(): Promise<string | null> {
     try {
       // 주의: 여기서는 전역 axios(기본 인스턴스) 사용하여 인터셉터 루프 방지
       const { data } = await axios.post<TokenInfo>(
-        `${API_BASE_URL}/auth/refresh`,
+        `${API_BASE_URL}/auth/token/refresh`,
         {},
         { withCredentials: true }
       );

--- a/src/libs/axios.ts
+++ b/src/libs/axios.ts
@@ -1,5 +1,4 @@
 import { API_BASE_URL, TOKEN_INFO_KEY } from "@/constants/api-constants";
-import type { TokenInfo } from "@/types/api-res-auth";
 import axios from "axios";
 
 const api = axios.create({
@@ -7,11 +6,10 @@ const api = axios.create({
 });
 
 api.interceptors.request.use((config) => {
-  const tokenStr = localStorage.getItem(TOKEN_INFO_KEY);
+  const accessToken = localStorage.getItem(TOKEN_INFO_KEY);
 
-  if (tokenStr) {
-    const tokenInfo: TokenInfo = JSON.parse(tokenStr);
-    config.headers.Authorization = `Bearer ${tokenInfo.access_token}`;
+  if (accessToken) {
+    config.headers.Authorization = `Bearer ${accessToken}`;
   }
 
   return config;

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -40,7 +40,8 @@ const LogIn = () => {
     },
 
     onSuccess: (res) => {
-      localStorage.setItem(TOKEN_INFO_KEY, JSON.stringify(res.data));
+      const accessToken = res.data.access_token;
+      localStorage.setItem(TOKEN_INFO_KEY, accessToken);
       refetch();
       navigate("/");
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,13 +2,28 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import path from "path";
+import fs from "fs";
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react(), tailwindcss()],
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
+export default defineConfig(({ mode }) => {
+  const isDev = mode === "development";
+
+  return {
+    plugins: [react(), tailwindcss()],
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+      },
     },
-  },
+    server: isDev
+      ? {
+          https: {
+            key: fs.readFileSync(path.resolve(__dirname, "localhost-key.pem")),
+            cert: fs.readFileSync(path.resolve(__dirname, "localhost.pem")),
+          },
+          host: "localhost",
+          port: 5173,
+        }
+      : undefined,
+  };
 });


### PR DESCRIPTION
## 📌 개요

로그인 로직 수정

## ✅ 작업 내용

- 로그인 로직 수정 (access 토큰만 로컬 스토리지에 저장하고 refresh token은 쿠키에 저장)
- 자동 리프레시
- https 서버로 변경

## ⚠️ 주의
- 앞으론 개발 시 주소를 무조건 https://localhost:5173 으로 고정!!
- 5174 등 다른 주소로 열면 CORS 오류

## 로컬에서 https로 여는 법
### 0. mkcert 설치
+ 이 브랜치 dev로 merge하고 나고 현재 작업 브랜치로 rebase!!!!

### 1. mkcert 설치
+ 아래 링크 참고해서 다운로드
https://github.com/FiloSottile/mkcert

### 2.  로컬 인증서 발급
+ 프로젝트 루트 폴더에서 아래 명령어 실행
```
mkcert localhost
```
+ 아래 두 개 파일이 생긴다.
  + localhost-key.pem -> private key
  + localhost.pem -> public key

+ 위 두개 파일은 절대 깃허브에 올리면 안된다!!!! (.gitignore 확인!!)

### 3. https 실행
+ npm run dev 하면 https로 실행됨
+ 자세한 내용은 vite.config.ts 체크


## 🔍 관련 이슈

Closes #205 

## 📸 스크린샷 (선택)

변경사항이 UI에 영향을 주었다면 스크린샷을 포함해주세요.
